### PR TITLE
🎨 UX: Swap Chat Title and Character Name Prominence (Issue #122)

### DIFF
--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -261,9 +261,9 @@ const ChatPage = ({ chatId }: ChatPageProps) => {
                       showSpinner={true}
                     />
                     <div className="ml-3">
-                      <h3 className="font-medium">{chat.title}</h3>
+                      <h3 className="font-medium">{chat.character?.name}</h3>
                       <p className="text-sm text-gray-400">
-                        {chat.character?.name}
+                        {chat.title}
                       </p>
                       <p className="text-xs text-gray-500">
                         {chat.updatedAt ? new Date(chat.updatedAt).toLocaleDateString() : ''}

--- a/client/src/pages/chats.tsx
+++ b/client/src/pages/chats.tsx
@@ -286,9 +286,9 @@ const ChatsPage = ({ chatId }: ChatsPageProps) => {
                       showSpinner={true}
                     />
                     <div className="ml-3 flex-1 min-w-0">
-                      <h3 className="font-medium truncate">{chat.title}</h3>
+                      <h3 className="font-medium truncate">{chat.character?.name}</h3>
                       <p className="text-sm text-gray-400">
-                        {chat.character?.name}
+                        {chat.title}
                       </p>
                       <p className="text-xs text-gray-500">
                         {chat.updatedAt ? new Date(chat.updatedAt).toLocaleDateString() : ''}


### PR DESCRIPTION
## Summary
Fixes the information hierarchy in chat lists by making character names prominent instead of generic chat titles, improving user experience when scanning for specific conversations.

## Changes Made
- **Swapped prominence** between chat titles and character names in both main chat views
- **Character names** (XN-7, 艾莉丝, Lyra) are now the primary heading with `font-medium` styling
- **Chat titles** ("与角色聊天") are now secondary with `text-sm text-gray-400` styling
- **Applied consistently** across main chat list (`chats.tsx`) and recent chats view (`chat.tsx`)

## Files Modified
- `client/src/pages/chat.tsx` - Lines 264-267 (main chat list view)
- `client/src/pages/chats.tsx` - Lines 289-292 (primary chat list page)

## Before vs After
**Before:** Generic "与角色聊天" titles were prominent, character names were secondary and gray
**After:** Character names are prominent and easily scannable, generic titles are appropriately de-emphasized

## Benefits
- ✅ **Better scanability** - Users can quickly find the character they want to chat with
- ✅ **Proper information hierarchy** - Most important info (character name) is most prominent  
- ✅ **Consistent with user mental model** - Users think "I want to chat with Alice" not "I want Chat #3"
- ✅ **Low-risk change** - Simple UI reordering with no logic changes

## Test Plan
- [x] Code review completed with code-reviewer agent
- [x] UI changes verified through browser automation
- [x] Information hierarchy now matches user expectations
- [x] Both chat list views display consistently

## Related
Closes #122

🤖 Generated with [Claude Code](https://claude.ai/code)