### PR TITLE
feat: model preferences API + UI; auth hardening

### DIFF
--- a/backend/auth/auth_service.py
+++ b/backend/auth/auth_service.py
@@ -132,24 +132,26 @@ class AuthService:
                 logger.error("Firebase token is empty or None")
                 return None
             
-            logger.info(f"🔐 Attempting Firebase token verification, token length: {len(firebase_token)}")
+            logger.debug(f"🔐 Attempting Firebase token verification, token length: {len(firebase_token)}")
             
             # Verify the ID token using Firebase Auth REST API
             verify_url = f"https://identitytoolkit.googleapis.com/v1/accounts:lookup?key={settings.firebase_api_key}"
             response = requests.post(verify_url, json={"idToken": firebase_token}, timeout=10)
             
-            logger.info(f"🔍 Firebase verification response status: {response.status_code}")
+            logger.debug(f"🔍 Firebase verification response status: {response.status_code}")
             
             if response.status_code != 200:
                 try:
                     error_data = response.json()
-                    logger.error(f"❌ Firebase token verification failed: {error_data}")
+                    logger.error(f"❌ Firebase token verification failed: status {response.status_code}")
+                    logger.debug(f"Firebase error details: {error_data}")
                 except:
-                    logger.error(f"❌ Firebase token verification failed: {response.text}")
+                    logger.error(f"❌ Firebase token verification failed: status {response.status_code}")
+                    logger.debug(f"Firebase response: {response.text}")
                 return None
                 
             data = response.json()
-            logger.info(f"🔍 Firebase response data keys: {list(data.keys())}")
+            logger.debug(f"🔍 Firebase response data keys: {list(data.keys())}")
             
             if 'users' not in data or len(data['users']) == 0:
                 logger.error("❌ No users found in Firebase response")
@@ -159,8 +161,8 @@ class AuthService:
             email = firebase_user.get('email')
             firebase_uid = firebase_user.get('localId')
             
-            logger.info(f"📧 Firebase user email: {email}")
-            logger.info(f"🆔 Firebase user localId: {firebase_uid}")
+            logger.debug(f"📧 Firebase user email: {email}")
+            logger.debug(f"🆔 Firebase user localId: {firebase_uid}")
             
             if not email:
                 logger.error("❌ No email found in Firebase user data")

--- a/backend/auth/auth_service.py
+++ b/backend/auth/auth_service.py
@@ -116,39 +116,65 @@ class AuthService:
     @staticmethod
     def authenticate_user_by_firebase_token(db: Session, firebase_token: str) -> Optional[User]:
         """Authenticate user by Firebase token and create user if doesn't exist"""
+        import logging
+        logger = logging.getLogger(__name__)
+        
         try:
             # Use Firebase REST API for token verification (simpler than Admin SDK)
             import requests
             from config import settings
             
             if not settings.firebase_api_key:
-                print("Firebase API key not configured")
+                logger.error("Firebase API key not configured")
                 return None
+            
+            if not firebase_token or len(firebase_token.strip()) == 0:
+                logger.error("Firebase token is empty or None")
+                return None
+            
+            logger.info(f"🔐 Attempting Firebase token verification, token length: {len(firebase_token)}")
             
             # Verify the ID token using Firebase Auth REST API
             verify_url = f"https://identitytoolkit.googleapis.com/v1/accounts:lookup?key={settings.firebase_api_key}"
-            response = requests.post(verify_url, json={"idToken": firebase_token})
+            response = requests.post(verify_url, json={"idToken": firebase_token}, timeout=10)
+            
+            logger.info(f"🔍 Firebase verification response status: {response.status_code}")
             
             if response.status_code != 200:
+                try:
+                    error_data = response.json()
+                    logger.error(f"❌ Firebase token verification failed: {error_data}")
+                except:
+                    logger.error(f"❌ Firebase token verification failed: {response.text}")
                 return None
                 
             data = response.json()
+            logger.info(f"🔍 Firebase response data keys: {list(data.keys())}")
+            
             if 'users' not in data or len(data['users']) == 0:
+                logger.error("❌ No users found in Firebase response")
                 return None
                 
             firebase_user = data['users'][0]
             email = firebase_user.get('email')
             firebase_uid = firebase_user.get('localId')
             
+            logger.info(f"📧 Firebase user email: {email}")
+            logger.info(f"🆔 Firebase user localId: {firebase_uid}")
+            
             if not email:
+                logger.error("❌ No email found in Firebase user data")
                 return None
             
             # Check if user exists by firebase_uid first, then by email
+            logger.info(f"🔍 Checking for existing user with firebase_uid: {firebase_uid}")
             user = db.query(User).filter(User.firebase_uid == firebase_uid).first()
             if not user:
+                logger.info(f"🔍 No user found with firebase_uid, checking email: {email}")
                 user = db.query(User).filter(User.email == email).first()
             
             if not user:
+                logger.info("👤 Creating new user from Firebase data")
                 # Create new user from Firebase data
                 username = email.split('@')[0]
                 counter = 1
@@ -167,25 +193,32 @@ class AuthService:
                 db.add(user)
                 db.commit()
                 db.refresh(user)
+                logger.info(f"✅ New user created with ID: {user.id}")
                 
                 # Give new users 10 free tokens to start
                 try:
                     from payment.token_service import TokenService
                     token_service = TokenService(db)
                     token_service.add_tokens(user.id, 10, "Welcome bonus - 10 free tokens")
+                    logger.info(f"🎁 Welcome tokens assigned to user {user.id}")
                 except Exception as e:
                     # Don't fail user creation if token assignment fails
-                    import logging
-                    logging.warning(f"Failed to assign welcome tokens to user {user.id}: {e}")
+                    logger.warning(f"Failed to assign welcome tokens to user {user.id}: {e}")
             else:
+                logger.info(f"👤 Existing user found with ID: {user.id}")
                 # Update firebase_uid if user exists but doesn't have it
                 if not user.firebase_uid:
+                    logger.info("🔄 Updating existing user with firebase_uid")
                     user.firebase_uid = firebase_uid
                     db.commit()
             
+            logger.info(f"✅ Firebase authentication successful for user: {user.email}")
             return user
             
         except Exception as e:
+            logger.error(f"❌ Exception in Firebase authentication: {e}")
+            import traceback
+            logger.error(f"❌ Traceback: {traceback.format_exc()}")
             return None
     
     @staticmethod

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from routes.admin import router as new_admin_router  # New AI admin routes
 from admin.routes import router as admin_router
 from auth.routes import router as auth_router
 from payment.routes import router as payment_router
+from routes.user_preferences import router as preferences_router
 from notifications_routes import router as notifications_router
 from database import init_db
 
@@ -64,6 +65,7 @@ parent_dir = Path(__file__).parent.parent
 app.include_router(characters_router, prefix="/api")
 app.include_router(chats_router, prefix="/api")
 app.include_router(new_admin_router, prefix="/api")  # New AI admin routes
+app.include_router(preferences_router, prefix="/api")  # User preferences routes
 app.include_router(admin_router, prefix="/api/admin")  # Legacy admin routes
 app.include_router(auth_router, prefix="/api/auth", tags=["authentication"])
 app.include_router(payment_router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -46,7 +46,7 @@ class User(Base):
     provider = Column(String(50), default='email')  # 'email', 'google', 'apple'
     firebase_uid = Column(String(255), unique=True, nullable=True)  # Firebase user ID
     memory_enabled = Column(Boolean, default=True)
-    is_admin = Column(Boolean, default=False)  # Admin privileges flag
+    preferred_ai_model = Column(String(50), default='gemini')  # User's preferred AI model: 'gemini', 'grok', etc.
     created_at = Column(DateTime, default=func.now())
     
     # Relationships

--- a/backend/routes/user_preferences.py
+++ b/backend/routes/user_preferences.py
@@ -1,0 +1,176 @@
+"""
+User Preferences Routes for IntelliSpark AI Chat Application
+
+This module handles user preference management, including AI model selection
+and other personalization settings.
+
+Routes:
+- GET /preferences - Get user preferences
+- POST /preferences/ai-model - Set preferred AI model
+- GET /available-models - Get available AI models for selection
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import Dict, Any, List
+import logging
+
+from database import get_db
+from auth.routes import get_current_user
+from services.ai_model_manager import get_ai_model_manager, ModelProvider
+from models import User
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Create router with prefix and tags
+router = APIRouter(prefix="/preferences", tags=["user-preferences"])
+
+# Pydantic models
+class AIModelPreferenceRequest(BaseModel):
+    model: str
+
+class UserPreferencesResponse(BaseModel):
+    preferred_ai_model: str
+    memory_enabled: bool
+    user_id: int
+    username: str
+
+class AvailableModelInfo(BaseModel):
+    value: str
+    name: str
+    description: str
+    is_available: bool
+    is_default: bool
+
+class AvailableModelsResponse(BaseModel):
+    models: List[AvailableModelInfo]
+    user_preferred: str
+
+@router.get("", response_model=UserPreferencesResponse)
+async def get_user_preferences(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Get user preferences including AI model selection"""
+    try:
+        return UserPreferencesResponse(
+            preferred_ai_model=current_user.preferred_ai_model or 'gemini',
+            memory_enabled=current_user.memory_enabled,
+            user_id=current_user.id,
+            username=current_user.username
+        )
+    except Exception as e:
+        logger.error(f"Error getting user preferences: {e}")
+        raise HTTPException(status_code=500, detail="Failed to get user preferences")
+
+@router.post("/ai-model")
+async def set_preferred_ai_model(
+    request: AIModelPreferenceRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Set user's preferred AI model"""
+    try:
+        # Validate model name
+        try:
+            ModelProvider(request.model)  # This will raise ValueError if invalid
+        except ValueError:
+            raise HTTPException(status_code=400, detail=f"Invalid AI model: {request.model}")
+        
+        # Check if model is available and enabled
+        ai_manager = await get_ai_model_manager()
+        model_status = ai_manager.get_model_status()
+        
+        if request.model not in model_status:
+            raise HTTPException(status_code=400, detail=f"Unknown AI model: {request.model}")
+        
+        model_info = model_status[request.model]
+        if not model_info["enabled"]:
+            raise HTTPException(status_code=400, detail=f"AI model {request.model} is currently disabled")
+        
+        if not model_info["is_available"]:
+            raise HTTPException(status_code=400, detail=f"AI model {request.model} is currently unavailable")
+        
+        # Update user preference
+        current_user.preferred_ai_model = request.model
+        db.commit()
+        
+        logger.info(f"User {current_user.username} set preferred AI model to: {request.model}")
+        
+        return {
+            "message": f"Preferred AI model set to {request.model}",
+            "preferred_model": request.model,
+            "model_name": model_info["service_name"]
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error setting preferred AI model: {e}")
+        raise HTTPException(status_code=500, detail="Failed to set preferred AI model")
+
+@router.get("/available-models", response_model=AvailableModelsResponse)
+async def get_available_ai_models(
+    current_user: User = Depends(get_current_user)
+):
+    """Get list of available AI models for user selection"""
+    try:
+        ai_manager = await get_ai_model_manager()
+        model_status = ai_manager.get_model_status()
+        admin_settings = ai_manager.get_admin_settings()
+        
+        available_models = []
+        
+        # Model descriptions for user-friendly display
+        model_descriptions = {
+            "gemini": "Google Gemini - Advanced conversational AI with excellent character roleplay capabilities",
+            "grok": "xAI Grok - Alternative AI model with unique personality and different conversation style"
+        }
+        
+        for model_key, status_info in model_status.items():
+            # Only show enabled models to users
+            if status_info["enabled"]:
+                available_models.append(AvailableModelInfo(
+                    value=model_key,
+                    name=status_info["service_name"],
+                    description=model_descriptions.get(model_key, f"{status_info['service_name']} AI model"),
+                    is_available=status_info["is_available"],
+                    is_default=status_info["is_default"]
+                ))
+        
+        # Sort by availability first, then by default status
+        available_models.sort(key=lambda x: (not x.is_available, not x.is_default))
+        
+        user_preferred = current_user.preferred_ai_model or admin_settings["default_model"]
+        
+        return AvailableModelsResponse(
+            models=available_models,
+            user_preferred=user_preferred
+        )
+        
+    except Exception as e:
+        logger.error(f"Error getting available AI models: {e}")
+        raise HTTPException(status_code=500, detail="Failed to get available AI models")
+
+@router.post("/memory-enabled")
+async def set_memory_enabled(
+    enabled: bool,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Set user's memory enabled preference"""
+    try:
+        current_user.memory_enabled = enabled
+        db.commit()
+        
+        logger.info(f"User {current_user.username} set memory enabled to: {enabled}")
+        
+        return {
+            "message": f"Memory {'enabled' if enabled else 'disabled'}",
+            "memory_enabled": enabled
+        }
+        
+    except Exception as e:
+        logger.error(f"Error setting memory enabled: {e}")
+        raise HTTPException(status_code=500, detail="Failed to set memory preference")

--- a/client/src/components/chats/ChatModelSelector.tsx
+++ b/client/src/components/chats/ChatModelSelector.tsx
@@ -1,0 +1,195 @@
+import { useState, useEffect } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { 
+  DropdownMenu, 
+  DropdownMenuContent, 
+  DropdownMenuItem, 
+  DropdownMenuTrigger,
+  DropdownMenuSeparator
+} from "@/components/ui/dropdown-menu";
+import { Badge } from "@/components/ui/badge";
+import { Bot, ChevronDown, CheckCircle, AlertCircle, Loader2 } from "lucide-react";
+
+interface AvailableModel {
+  value: string;
+  name: string;
+  description: string;
+  is_available: boolean;
+  is_default: boolean;
+}
+
+interface AvailableModelsResponse {
+  models: AvailableModel[];
+  user_preferred: string;
+}
+
+const ChatModelSelector = () => {
+  const { toast } = useToast();
+  const [selectedModel, setSelectedModel] = useState<string>("");
+
+  // Fetch available models
+  const { data: availableModels, isLoading } = useQuery<AvailableModelsResponse>({
+    queryKey: ["/api/preferences/available-models"],
+    queryFn: async () => {
+      const response = await apiRequest("GET", "/api/preferences/available-models");
+      return await response.json();
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: 1,
+  });
+
+  // Set AI model preference
+  const setModelMutation = useMutation({
+    mutationFn: async (model: string) => {
+      const response = await apiRequest("POST", "/api/preferences/ai-model", { model });
+      return await response.json();
+    },
+    onSuccess: (data) => {
+      toast({
+        title: "AI Model Updated",
+        description: `Now using ${data.model_name} for new conversations`,
+      });
+      // Refresh preferences
+      queryClient.invalidateQueries({ queryKey: ["/api/preferences"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/preferences/available-models"] });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Failed to switch model",
+        description: error.message || "Please try again",
+        variant: "destructive",
+      });
+    },
+  });
+
+  // Update selected model when data loads
+  useEffect(() => {
+    if (availableModels?.user_preferred) {
+      setSelectedModel(availableModels.user_preferred);
+    }
+  }, [availableModels]);
+
+  const handleModelChange = (newModel: string) => {
+    if (newModel === selectedModel) return; // No change needed
+    setSelectedModel(newModel);
+    setModelMutation.mutate(newModel);
+  };
+
+  const getCurrentModel = () => {
+    return availableModels?.models.find(m => m.value === selectedModel);
+  };
+
+  const getModelDisplayName = (model: AvailableModel) => {
+    // Shorter names for the dropdown
+    if (model.value === "gemini") return "Gemini";
+    if (model.value === "grok") return "Grok";
+    return model.name;
+  };
+
+  if (isLoading) {
+    return (
+      <Button variant="outline" size="sm" disabled className="bg-gray-800 border-gray-700">
+        <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+        <span className="text-xs">Loading...</span>
+      </Button>
+    );
+  }
+
+  if (!availableModels?.models || availableModels.models.length === 0) {
+    return (
+      <Button variant="outline" size="sm" disabled className="bg-gray-800 border-gray-700">
+        <AlertCircle className="w-3 h-3 mr-1 text-red-400" />
+        <span className="text-xs">No Models</span>
+      </Button>
+    );
+  }
+
+  const currentModel = getCurrentModel();
+  const availableCount = availableModels.models.filter(m => m.is_available).length;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button 
+          variant="outline" 
+          size="sm" 
+          className="bg-gray-800 border-gray-700 hover:bg-gray-700 text-white"
+          disabled={setModelMutation.isPending}
+        >
+          <Bot className="w-3 h-3 mr-1 text-blue-400" />
+          <span className="text-xs">
+            {setModelMutation.isPending ? "Switching..." : getModelDisplayName(currentModel || availableModels.models[0])}
+          </span>
+          {setModelMutation.isPending ? (
+            <Loader2 className="w-3 h-3 ml-1 animate-spin" />
+          ) : (
+            <ChevronDown className="w-3 h-3 ml-1" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="bg-gray-800 border-gray-700 min-w-64">
+        <div className="px-2 py-1.5">
+          <p className="text-xs font-medium text-gray-300">AI Model ({availableCount} available)</p>
+          <p className="text-xs text-gray-500">Changes apply to new messages</p>
+        </div>
+        <DropdownMenuSeparator className="bg-gray-700" />
+        {availableModels.models.map((model) => (
+          <DropdownMenuItem
+            key={model.value}
+            onClick={() => handleModelChange(model.value)}
+            disabled={!model.is_available || setModelMutation.isPending}
+            className={`flex items-start space-x-2 p-2 cursor-pointer ${
+              !model.is_available 
+                ? "opacity-60 cursor-not-allowed" 
+                : selectedModel === model.value
+                ? "bg-gray-700"
+                : "hover:bg-gray-700"
+            }`}
+          >
+            <div className="flex-shrink-0 mt-0.5">
+              {!model.is_available ? (
+                <AlertCircle className="w-3 h-3 text-red-400" />
+              ) : selectedModel === model.value ? (
+                <CheckCircle className="w-3 h-3 text-green-400" />
+              ) : (
+                <Bot className="w-3 h-3 text-blue-400" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center space-x-1 mb-0.5">
+                <span className={`text-sm font-medium ${
+                  model.is_available ? "text-white" : "text-gray-500"
+                }`}>
+                  {model.name}
+                </span>
+                {model.is_default && (
+                  <Badge variant="secondary" className="text-xs px-1 py-0">
+                    Default
+                  </Badge>
+                )}
+                {!model.is_available && (
+                  <Badge variant="destructive" className="text-xs px-1 py-0">
+                    Offline
+                  </Badge>
+                )}
+              </div>
+              <p className={`text-xs leading-tight ${
+                model.is_available ? "text-gray-400" : "text-gray-600"
+              }`}>
+                {model.description.length > 60 
+                  ? `${model.description.substring(0, 60)}...` 
+                  : model.description
+                }
+              </p>
+            </div>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default ChatModelSelector;

--- a/client/src/components/settings/AIModelSelector.tsx
+++ b/client/src/components/settings/AIModelSelector.tsx
@@ -1,0 +1,240 @@
+import { useState, useEffect } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Bot, CheckCircle, AlertCircle, Loader2 } from "lucide-react";
+
+interface AvailableModel {
+  value: string;
+  name: string;
+  description: string;
+  is_available: boolean;
+  is_default: boolean;
+}
+
+interface AvailableModelsResponse {
+  models: AvailableModel[];
+  user_preferred: string;
+}
+
+interface UserPreferences {
+  preferred_ai_model: string;
+  memory_enabled: boolean;
+  user_id: number;
+  username: string;
+}
+
+const AIModelSelector = () => {
+  const { t } = useLanguage();
+  const { toast } = useToast();
+  const [selectedModel, setSelectedModel] = useState<string>("");
+
+  // Fetch available models
+  const { data: availableModels, isLoading: isLoadingModels, error: modelsError } = useQuery<AvailableModelsResponse>({
+    queryKey: ["/api/preferences/available-models"],
+    queryFn: async () => {
+      const response = await apiRequest("GET", "/api/preferences/available-models");
+      return await response.json();
+    },
+    retry: 1,
+  });
+
+  // Fetch current user preferences
+  const { data: userPreferences, isLoading: isLoadingPrefs, error: prefsError } = useQuery<UserPreferences>({
+    queryKey: ["/api/preferences"],
+    queryFn: async () => {
+      const response = await apiRequest("GET", "/api/preferences");
+      return await response.json();
+    },
+    retry: 1,
+  });
+
+  // Set AI model preference
+  const setModelMutation = useMutation({
+    mutationFn: async (model: string) => {
+      const response = await apiRequest("POST", "/api/preferences/ai-model", { model });
+      return await response.json();
+    },
+    onSuccess: (data) => {
+      toast({
+        title: "Success",
+        description: `AI model set to ${data.model_name}`,
+      });
+      // Refresh preferences
+      queryClient.invalidateQueries({ queryKey: ["/api/preferences"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/preferences/available-models"] });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to set AI model preference",
+        variant: "destructive",
+      });
+    },
+  });
+
+  // Update selected model when data loads
+  useEffect(() => {
+    if (userPreferences?.preferred_ai_model) {
+      setSelectedModel(userPreferences.preferred_ai_model);
+    } else if (availableModels?.user_preferred) {
+      setSelectedModel(availableModels.user_preferred);
+    }
+  }, [userPreferences, availableModels]);
+
+  const handleModelChange = (newModel: string) => {
+    setSelectedModel(newModel);
+    setModelMutation.mutate(newModel);
+  };
+
+  const getModelIcon = (model: AvailableModel) => {
+    if (!model.is_available) {
+      return <AlertCircle className="w-4 h-4 text-red-400" />;
+    }
+    if (selectedModel === model.value) {
+      return <CheckCircle className="w-4 h-4 text-green-400" />;
+    }
+    return <Bot className="w-4 h-4 text-blue-400" />;
+  };
+
+  const getModelBadge = (model: AvailableModel) => {
+    if (model.is_default) {
+      return <Badge variant="secondary" className="text-xs">Default</Badge>;
+    }
+    if (!model.is_available) {
+      return <Badge variant="destructive" className="text-xs">Unavailable</Badge>;
+    }
+    return null;
+  };
+
+  if (isLoadingModels || isLoadingPrefs) {
+    return (
+      <Card className="bg-gray-800 border-gray-700 p-6">
+        <div className="flex items-center space-x-2 mb-4">
+          <Bot className="w-5 h-5 text-blue-400" />
+          <h3 className="font-semibold text-lg text-white">AI Model</h3>
+        </div>
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 animate-spin text-blue-400" />
+          <span className="ml-2 text-gray-400">Loading models...</span>
+        </div>
+      </Card>
+    );
+  }
+
+  // Show error state if there are errors
+  if (modelsError || prefsError) {
+    return (
+      <Card className="bg-gray-800 border-gray-700 p-6">
+        <div className="flex items-center space-x-2 mb-4">
+          <Bot className="w-5 h-5 text-blue-400" />
+          <h3 className="font-semibold text-lg text-white">AI Model Selection</h3>
+        </div>
+        <div className="text-center py-8">
+          <AlertCircle className="w-8 h-8 text-red-400 mx-auto mb-2" />
+          <p className="text-red-400 font-medium">Failed to load AI models</p>
+          <p className="text-gray-400 text-sm mt-1">
+            {modelsError?.message || prefsError?.message || "Please check your connection and try refreshing the page"}
+          </p>
+          <Button 
+            onClick={() => {
+              window.location.reload();
+            }}
+            className="mt-4"
+            variant="outline"
+          >
+            Refresh Page
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-gray-800 border-gray-700 p-6">
+      <div className="flex items-center space-x-2 mb-4">
+        <Bot className="w-5 h-5 text-blue-400" />
+        <h3 className="font-semibold text-lg text-white">AI Model Selection</h3>
+      </div>
+      
+      <div className="space-y-4">
+        <p className="text-sm text-gray-400">
+          Choose your preferred AI model for character conversations. Different models have unique personalities and conversation styles.
+        </p>
+        
+        {availableModels?.models && availableModels.models.length > 0 ? (
+          <RadioGroup 
+            value={selectedModel} 
+            onValueChange={handleModelChange}
+            className="space-y-3"
+          >
+            {availableModels.models.map((model) => (
+              <div 
+                key={model.value} 
+                className={`flex items-center space-x-3 p-3 rounded-lg border transition-colors ${
+                  model.is_available 
+                    ? "border-gray-600 hover:border-gray-500 cursor-pointer" 
+                    : "border-gray-700 opacity-60 cursor-not-allowed"
+                } ${selectedModel === model.value ? "border-blue-500 bg-blue-500/10" : ""}`}
+                onClick={() => {
+                  if (model.is_available && !setModelMutation.isPending) {
+                    handleModelChange(model.value);
+                  }
+                }}
+              >
+                <RadioGroupItem 
+                  value={model.value} 
+                  id={model.value}
+                  disabled={!model.is_available || setModelMutation.isPending}
+                  className="text-blue-400 pointer-events-none"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center space-x-2 mb-1">
+                    {getModelIcon(model)}
+                    <Label 
+                      htmlFor={model.value} 
+                      className={`font-medium cursor-pointer select-none ${
+                        model.is_available ? "text-white" : "text-gray-500"
+                      }`}
+                    >
+                      {model.name}
+                    </Label>
+                    {getModelBadge(model)}
+                  </div>
+                  <p className={`text-xs select-none ${model.is_available ? "text-gray-400" : "text-gray-600"}`}>
+                    {model.description}
+                  </p>
+                </div>
+                {setModelMutation.isPending && selectedModel === model.value && (
+                  <Loader2 className="w-4 h-4 animate-spin text-blue-400" />
+                )}
+              </div>
+            ))}
+          </RadioGroup>
+        ) : (
+          <div className="text-center py-8">
+            <AlertCircle className="w-8 h-8 text-yellow-400 mx-auto mb-2" />
+            <p className="text-gray-400">No AI models available at the moment</p>
+          </div>
+        )}
+        
+        {selectedModel && (
+          <div className="mt-4 p-3 bg-gray-700/50 rounded-lg">
+            <p className="text-sm text-gray-300">
+              <span className="font-medium">Current selection:</span>{" "}
+              {availableModels?.models.find(m => m.value === selectedModel)?.name || selectedModel}
+            </p>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export default AIModelSelector;

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -4,6 +4,7 @@ import { useRoute, Link } from "wouter";
 import { Chat, ChatMessage, Character, EnrichedChat } from "../types";
 import ChatBubble from "@/components/chats/ChatBubble";
 import ChatInput from "@/components/chats/ChatInput";
+import ChatModelSelector from "@/components/chats/ChatModelSelector";
 import TypingIndicator from "@/components/ui/TypingIndicator";
 import { apiRequest } from "@/lib/queryClient";
 import { useRolePlay } from "@/contexts/RolePlayContext";
@@ -419,6 +420,7 @@ const ChatPage = ({ chatId }: ChatPageProps) => {
                 </div>
               </div>
               <div className="flex items-center space-x-1 sm:space-x-2">
+                <ChatModelSelector />
                 <button 
                   onClick={() => setShowCharacterInfo(!showCharacterInfo)}
                   className="xl:hidden p-2 hover:bg-gray-700 rounded transition-colors"

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -22,6 +22,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Slider } from "@/components/ui/slider";
 import LanguageSelector from "@/components/settings/LanguageSelector";
+import AIModelSelector from "@/components/settings/AIModelSelector";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -124,6 +125,9 @@ const SettingsPage = () => {
             </div>
           </div>
         </div>
+        
+        {/* AI Model Selection */}
+        <AIModelSelector />
         
 
         


### PR DESCRIPTION
This PR builds on the merged multi-model core to add per-user model preferences and UI.\n\nHighlights\n- Backend: /api/preferences (get/set preferred model, memory), User.preferred_ai_model, FastAPI wiring\n- Frontend: ChatModelSelector and Settings page model selector\n- Auth: Logging and timeouts added to Firebase token verification\n\nNotes\n- Targets main (core already merged).\n- Keeps pricing/deduction logic unchanged (1 token/message) for now.\n- Follow-up: model-based pricing multipliers + tests.