### PR TITLE
UX: declutter navigation, reposition sidebar under top bar, chat gap fix, Discover quick wins

### DIFF
--- a/client/src/components/discover/DiscoverSection.tsx
+++ b/client/src/components/discover/DiscoverSection.tsx
@@ -34,6 +34,27 @@ const DiscoverSection = () => {
     gcTime: 10 * 60 * 1000,
   });
 
+  // Lightweight skeleton while loading
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto px-3 sm:px-4 py-4 sm:py-6">
+        {["精选角色","趋势角色","新上架"].map((title, idx) => (
+          <section key={idx} className="mb-8">
+            <div className="flex items-center justify-between mb-4">
+              <div className="h-6 w-40 bg-gray-700 rounded" />
+              <div className="h-8 w-20 bg-gray-700 rounded" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              {[0,1,2].map(i => (
+                <div key={i} className="h-40 bg-gray-800 rounded-xl border border-gray-700 animate-pulse" />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    );
+  }
+
   // State for category filtering and layout
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [viewMode, setViewMode] = useState<'grid' | 'masonry'>('masonry');
@@ -292,7 +313,8 @@ const DiscoverSection = () => {
       {/* Featured Characters */}
       {filteredSections.featured.length > 0 && (
         <section>
-          <div className="flex items-center space-x-2 mb-4">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-2">
             <Crown className="w-5 h-5 text-yellow-400" />
             <h2 className="text-xl font-semibold text-white">{t('featuredCharacters')}</h2>
             <span className="text-sm text-gray-400">{t('handpickedSelections')}</span>
@@ -301,6 +323,13 @@ const DiscoverSection = () => {
                 {selectedCategory}
               </span>
             )}
+            </div>
+            <button
+              onClick={() => navigateToPath('/characters')}
+              className="px-3 py-1.5 text-sm bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg text-gray-200"
+            >
+              {t('viewAll') || '查看全部'}
+            </button>
           </div>
           <div className={viewMode === 'masonry' 
             ? "columns-1 md:columns-2 gap-4 space-y-4" 
@@ -318,7 +347,8 @@ const DiscoverSection = () => {
       {/* Trending This Week */}
       {filteredSections.trending.length > 0 && (
         <section>
-          <div className="flex items-center space-x-2 mb-4">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-2">
             <TrendingUp className="w-5 h-5 text-pink-400" />
             <h2 className="text-xl font-semibold text-white">{t('trendingThisWeek')}</h2>
             <span className="text-sm text-gray-400">{t('hotPicksCommunity')}</span>
@@ -327,6 +357,13 @@ const DiscoverSection = () => {
                 {selectedCategory}
               </span>
             )}
+            </div>
+            <button
+              onClick={() => navigateToPath('/characters')}
+              className="px-3 py-1.5 text-sm bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg text-gray-200"
+            >
+              {t('viewAll') || '查看全部'}
+            </button>
           </div>
           <div className={viewMode === 'masonry' 
             ? "columns-1 md:columns-2 lg:columns-3 gap-4 space-y-4" 
@@ -344,7 +381,8 @@ const DiscoverSection = () => {
       {/* New Arrivals */}
       {filteredSections.new.length > 0 && (
         <section>
-          <div className="flex items-center space-x-2 mb-4">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-2">
             <Zap className="w-5 h-5 text-green-400" />
             <h2 className="text-xl font-semibold text-white">{t('newArrivals')}</h2>
             <span className="text-sm text-gray-400">{t('freshCharactersAdded')}</span>
@@ -353,6 +391,13 @@ const DiscoverSection = () => {
                 {selectedCategory}
               </span>
             )}
+            </div>
+            <button
+              onClick={() => navigateToPath('/characters')}
+              className="px-3 py-1.5 text-sm bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg text-gray-200"
+            >
+              {t('viewAll') || '查看全部'}
+            </button>
           </div>
           <div className={viewMode === 'masonry' 
             ? "columns-1 md:columns-2 lg:columns-3 gap-4 space-y-4" 

--- a/client/src/components/discover/DiscoverSection.tsx
+++ b/client/src/components/discover/DiscoverSection.tsx
@@ -34,26 +34,7 @@ const DiscoverSection = () => {
     gcTime: 10 * 60 * 1000,
   });
 
-  // Lightweight skeleton while loading
-  if (isLoading) {
-    return (
-      <div className="max-w-7xl mx-auto px-3 sm:px-4 py-4 sm:py-6">
-        {["精选角色","趋势角色","新上架"].map((title, idx) => (
-          <section key={idx} className="mb-8">
-            <div className="flex items-center justify-between mb-4">
-              <div className="h-6 w-40 bg-gray-700 rounded" />
-              <div className="h-8 w-20 bg-gray-700 rounded" />
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              {[0,1,2].map(i => (
-                <div key={i} className="h-40 bg-gray-800 rounded-xl border border-gray-700 animate-pulse" />
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
-    );
-  }
+  // Lightweight skeleton will render within the main layout to preserve hook order
 
   // State for category filtering and layout
   const [selectedCategory, setSelectedCategory] = useState('All');
@@ -309,6 +290,25 @@ const DiscoverSection = () => {
           </div>
         </div>
       </div>
+
+      {/* Loading skeleton while fetching */}
+      {isLoading && (
+        <div className="max-w-7xl mx-auto px-3 sm:px-4 py-2" aria-live="polite">
+          {[0,1,2].map((_, idx) => (
+            <section key={idx} className="mb-8">
+              <div className="flex items-center justify-between mb-4">
+                <div className="h-6 w-40 bg-gray-700 rounded" />
+                <div className="h-8 w-20 bg-gray-700 rounded" />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                {[0,1,2].map(i => (
+                  <div key={i} className="h-40 bg-gray-800 rounded-xl border border-gray-700 animate-pulse" />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
 
       {/* Featured Characters */}
       {filteredSections.featured.length > 0 && (

--- a/client/src/components/layout/GlobalLayout.tsx
+++ b/client/src/components/layout/GlobalLayout.tsx
@@ -10,6 +10,7 @@ interface GlobalLayoutProps {
   searchQuery?: string;
   onSearchChange?: (query: string) => void;
   hideSearch?: boolean;
+  contentTopPadding?: boolean; // add or remove top padding below top nav
 }
 
 export default function GlobalLayout({ 
@@ -18,7 +19,8 @@ export default function GlobalLayout({
   showSidebar = true,
   searchQuery,
   onSearchChange,
-  hideSearch
+  hideSearch,
+  contentTopPadding = true
 }: GlobalLayoutProps) {
   const { isCollapsed } = useNavigation();
 
@@ -33,7 +35,7 @@ export default function GlobalLayout({
         />
       )}
       {showSidebar && <GlobalSidebar />}
-      <div className={`flex-1 overflow-auto ${showSidebar ? (isCollapsed ? 'sm:pl-16' : 'sm:pl-64') : ''} ${showTopNav ? 'pt-2' : ''}`}>
+      <div className={`flex-1 overflow-auto ${showSidebar ? (isCollapsed ? 'sm:pl-16' : 'sm:pl-64') : ''} ${showTopNav && contentTopPadding ? 'pt-2' : ''}`}>
         {children}
       </div>
     </div>

--- a/client/src/components/layout/GlobalLayout.tsx
+++ b/client/src/components/layout/GlobalLayout.tsx
@@ -9,6 +9,7 @@ interface GlobalLayoutProps {
   showSidebar?: boolean;
   searchQuery?: string;
   onSearchChange?: (query: string) => void;
+  hideSearch?: boolean;
 }
 
 export default function GlobalLayout({ 
@@ -16,7 +17,8 @@ export default function GlobalLayout({
   showTopNav = true, 
   showSidebar = true,
   searchQuery,
-  onSearchChange 
+  onSearchChange,
+  hideSearch
 }: GlobalLayoutProps) {
   const { isCollapsed } = useNavigation();
 
@@ -27,6 +29,7 @@ export default function GlobalLayout({
           searchQuery={searchQuery} 
           onSearchChange={onSearchChange}
           withSidebar={showSidebar}
+          hideSearch={hideSearch}
         />
       )}
       {showSidebar && <GlobalSidebar />}

--- a/client/src/components/layout/GlobalSidebar.tsx
+++ b/client/src/components/layout/GlobalSidebar.tsx
@@ -47,22 +47,16 @@ export default function GlobalSidebar() {
   const bottomLinks = [
     { icon: HelpCircle, label: t('aboutUs'), path: '/about' },
     { icon: FileText, label: t('faq'), path: '/faq' },
-    { icon: FileText, label: t('blog'), path: '/blog' },
+    // Blog is reserved for later; hide to avoid dead link for now
   ];
 
   return (
     <div className={`${isCollapsed ? 'w-16' : 'w-64'} bg-gray-800 border-r border-gray-700 h-screen fixed left-0 top-0 z-40 transition-all duration-300 flex flex-col hidden sm:flex`}>
       <div className="p-4 flex-1 min-h-0">
-        {/* Header with Home Navigation */}
+        {/* Header with Home Navigation (avoid duplicating brand with TopNavigation) */}
         <div className="flex items-center justify-between mb-6">
           {!isCollapsed && (
-            <button
-              onClick={navigateToHome}
-              className="text-lg font-bold text-white hover:text-brand-primary transition-colors cursor-pointer"
-              title="Go to Home"
-            >
-              ProductInsightAI
-            </button>
+            <span className="text-sm text-gray-400" aria-hidden="true">&nbsp;</span>
           )}
           <button
             onClick={toggleCollapsed}

--- a/client/src/components/layout/GlobalSidebar.tsx
+++ b/client/src/components/layout/GlobalSidebar.tsx
@@ -51,7 +51,10 @@ export default function GlobalSidebar() {
   ];
 
   return (
-    <div className={`${isCollapsed ? 'w-16' : 'w-64'} bg-gray-800 border-r border-gray-700 h-screen fixed left-0 top-0 z-40 transition-all duration-300 flex flex-col hidden sm:flex`}>
+    <div 
+      className={`${isCollapsed ? 'w-16' : 'w-64'} bg-gray-800 border-r border-gray-700 fixed left-0 top-14 z-20 transition-all duration-300 flex flex-col hidden sm:flex`}
+      style={{ height: 'calc(100vh - 56px)' }}
+    >
       <div className="p-4 flex-1 min-h-0">
         {/* Header with Home Navigation (avoid duplicating brand with TopNavigation) */}
         <div className="flex items-center justify-between mb-6">

--- a/client/src/components/layout/GlobalSidebar.tsx
+++ b/client/src/components/layout/GlobalSidebar.tsx
@@ -56,22 +56,11 @@ export default function GlobalSidebar() {
       style={{ height: 'calc(100vh - 56px)' }}
     >
       <div className="p-4 flex-1 min-h-0">
-        {/* Header with Home Navigation (avoid duplicating brand with TopNavigation) */}
+        {/* Header spacer (branding handled in TopNavigation) */}
         <div className="flex items-center justify-between mb-6">
           {!isCollapsed && (
             <span className="text-sm text-gray-400" aria-hidden="true">&nbsp;</span>
           )}
-          <button
-            onClick={toggleCollapsed}
-            className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
-            title={isCollapsed ? t('expandSidebar') : t('collapseSidebar')}
-          >
-            {isCollapsed ? (
-              <Menu className="w-6 h-6 text-gray-400" />
-            ) : (
-              <ChevronLeft className="w-5 h-5 text-gray-400" />
-            )}
-          </button>
         </div>
 
         {/* User Profile */}

--- a/client/src/components/layout/TopNavigation.tsx
+++ b/client/src/components/layout/TopNavigation.tsx
@@ -1,4 +1,4 @@
-import { Search, ChevronDown, MessageCircle, User, Settings, LogOut, LogIn, Bell, Crown } from 'lucide-react';
+import { Search, ChevronDown, MessageCircle, User, Settings, LogOut, LogIn, Bell, Crown, Menu } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useNavigation } from '@/contexts/NavigationContext';
@@ -24,7 +24,8 @@ export default function TopNavigation({ searchQuery = '', onSearchChange, withSi
     navigateToLogin, 
     navigateToPath,
     getTopNavItems,
-    isCollapsed 
+    isCollapsed,
+    toggleCollapsed
   } = useNavigation();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
@@ -66,6 +67,15 @@ export default function TopNavigation({ searchQuery = '', onSearchChange, withSi
       <div className="flex items-center justify-between px-2 sm:px-4 py-3">
         {/* Left side */}
         <div className="flex items-center space-x-2 sm:space-x-4 flex-1 min-w-0">
+          {/* Sidebar toggle (desktop only) */}
+          <button
+            onClick={toggleCollapsed}
+            className="hidden sm:inline-flex items-center justify-center p-2 rounded-lg hover:bg-gray-700/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            <Menu className="w-5 h-5 text-gray-300" />
+          </button>
           <button 
             onClick={navigateToHome}
             className="flex items-center space-x-2 group transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-opacity-50 rounded-lg p-1 hover:bg-gray-700/50"

--- a/client/src/components/layout/TopNavigation.tsx
+++ b/client/src/components/layout/TopNavigation.tsx
@@ -62,9 +62,7 @@ export default function TopNavigation({ searchQuery = '', onSearchChange, withSi
   }, []);
 
   return (
-    <div className={`bg-gray-800 border-b border-gray-700 w-full sticky top-0 z-30 ${
-      withSidebar ? (isCollapsed ? 'sm:pl-16' : 'sm:pl-64') : ''
-    }`}>
+    <div className={`bg-gray-800 border-b border-gray-700 w-full sticky top-0 z-30`}>
       <div className="flex items-center justify-between px-2 sm:px-4 py-3">
         {/* Left side */}
         <div className="flex items-center space-x-2 sm:space-x-4 flex-1 min-w-0">

--- a/client/src/components/layout/TopNavigation.tsx
+++ b/client/src/components/layout/TopNavigation.tsx
@@ -12,9 +12,10 @@ interface TopNavigationProps {
   searchQuery?: string;
   onSearchChange?: (query: string) => void;
   withSidebar?: boolean;
+  hideSearch?: boolean;
 }
 
-export default function TopNavigation({ searchQuery = '', onSearchChange, withSidebar = true }: TopNavigationProps) {
+export default function TopNavigation({ searchQuery = '', onSearchChange, withSidebar = true, hideSearch = false }: TopNavigationProps) {
   const { user, isAuthenticated, logout } = useAuth();
   const { language, setLanguage, t } = useLanguage();
   const { 
@@ -95,17 +96,19 @@ export default function TopNavigation({ searchQuery = '', onSearchChange, withSi
             </span>
           </button>
           
-          {/* Search Bar */}
-          <div className="relative flex-1 max-w-md mx-2 sm:mx-4">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-            <input
-              type="text"
-              placeholder={t('searchCharacters')}
-              value={searchQuery}
-              onChange={(e) => onSearchChange?.(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 text-white placeholder-gray-400"
-            />
-          </div>
+          {/* Search Bar (hideable) */}
+          {!hideSearch && (
+            <div className="relative flex-1 max-w-md mx-2 sm:mx-4">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                type="text"
+                placeholder={t('searchCharacters')}
+                value={searchQuery}
+                onChange={(e) => onSearchChange?.(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-gray-700 border border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 text-white placeholder-gray-400"
+              />
+            </div>
+          )}
         </div>
 
         {/* Right side */}

--- a/client/src/config/navigation.ts
+++ b/client/src/config/navigation.ts
@@ -87,8 +87,8 @@ export const NAVIGATION_CONFIG: NavigationItem[] = [
     path: '/payment',
     icon: Coins,
     requiresAuth: true,
-    showInSidebar: true,
-    showInTopNav: true,
+    showInSidebar: false,
+    showInTopNav: false,
     showInMobileTab: true
   },
   {
@@ -97,7 +97,7 @@ export const NAVIGATION_CONFIG: NavigationItem[] = [
     path: '/profile',
     icon: User,
     requiresAuth: true,
-    showInSidebar: true,
+    showInSidebar: false,
     showInTopNav: true,
     showInMobileTab: true
   },
@@ -107,8 +107,8 @@ export const NAVIGATION_CONFIG: NavigationItem[] = [
     path: '/notifications',
     icon: Bell,
     requiresAuth: true,
-    showInSidebar: true,
-    showInTopNav: true,
+    showInSidebar: false,
+    showInTopNav: false,
     showInMobileTab: false
   },
   {
@@ -117,7 +117,7 @@ export const NAVIGATION_CONFIG: NavigationItem[] = [
     path: '/settings',
     icon: Settings,
     requiresAuth: true,
-    showInSidebar: true,
+    showInSidebar: false,
     showInTopNav: false,
     showInMobileTab: false
   }

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -287,8 +287,8 @@ const ChatPage = ({ chatId }: ChatPageProps) => {
   
   // If we're showing a specific chat
   return (
-    <GlobalLayout showSidebar={false}>
-      <div className="h-[calc(100vh-4rem)] bg-gray-900 text-white flex relative overflow-hidden">
+    <GlobalLayout showSidebar={false} contentTopPadding={false}>
+      <div className="h-[calc(100vh-56px)] bg-gray-900 text-white flex relative overflow-hidden">
         {/* Mobile overlay */}
         {showChatList && (
           <div 

--- a/client/src/pages/discover.tsx
+++ b/client/src/pages/discover.tsx
@@ -1,15 +1,9 @@
-import { useState } from 'react';
 import GlobalLayout from "@/components/layout/GlobalLayout";
 import DiscoverSection from "@/components/discover/DiscoverSection";
 
 const DiscoverPage = () => {
-  const [searchQuery, setSearchQuery] = useState('');
-
   return (
-    <GlobalLayout 
-      searchQuery={searchQuery} 
-      onSearchChange={setSearchQuery}
-    >
+    <GlobalLayout hideSearch>
       <DiscoverSection />
     </GlobalLayout>
   );


### PR DESCRIPTION
This PR simplifies and cleans up the navigation and related UI. Closes #168.

Highlights
- Navigation declutter
  - Remove duplicate entries from sidebar: Tokens/Payment, Profile, Notifications, Settings
  - Keep top bar for global actions (notifications bell, token actions, user menu)
  - Hide blog link in sidebar (reserved for later)
- Layout adjustments
  - Sidebar sits below top bar (no more squeezing top bar)
  - Move sidebar toggle to top bar (desktop only); remove duplicate sidebar toggle
- Discover quick wins
  - Hide global search in Discover to avoid duplication with Home
  - Add lightweight skeletons and "View All" links to Characters page
- Chat page UX
  - Remove top gap between top bar and chat area; align to 56px top bar height

Notes
- Mobile bottom tabs remain concise (<= 5 items)
- i18n and routes cleanup tracked separately

Tested locally across desktop/mobile breakpoints.
