### PR TITLE
Remove test pricing tier from production

### DIFF
--- a/backend/payment/token_service.py
+++ b/backend/payment/token_service.py
@@ -290,11 +290,6 @@ class TokenService:
 
 # Pricing tiers configuration - One-time token purchases
 PRICING_TIERS = {
-    "test": {
-        "tokens": 1,
-        "price": 50,  # $0.50 in cents (USD) - MINIMAL TEST AMOUNT
-        "description": "Test - 1 token",
-    },
     "starter": {
         "tokens": 100,
         "price": 299,  # $2.99 in cents (USD)


### PR DESCRIPTION
Removes the test tier (1 token/$0.50) from PRICING_TIERS. Production now only shows starter, standard, and premium tiers.