### PR TITLE
feat(tts): add end-to-end audio generation + UX handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -33,12 +33,14 @@ try:
     from routes.admin import router as new_admin_router  # New AI admin routes
     from routes.search import router as search_router  # Search routes
     from routes.user_preferences import router as preferences_router
+    from routes.tts_routes import router as tts_router
 except ModuleNotFoundError:
     from backend.routes.characters import router as characters_router
     from backend.routes.chats import router as chats_router
     from backend.routes.admin import router as new_admin_router  # New AI admin routes
     from backend.routes.search import router as search_router  # Search routes
     from backend.routes.user_preferences import router as preferences_router
+    from backend.routes.tts_routes import router as tts_router
 
 try:
     from admin.routes import router as admin_router
@@ -153,6 +155,7 @@ app.include_router(chats_router, prefix="/api")
 app.include_router(new_admin_router, prefix="/api")  # New AI admin routes
 app.include_router(search_router, prefix="/api")  # Search routes
 app.include_router(preferences_router, prefix="/api")  # User preferences routes
+app.include_router(tts_router, prefix="/api")
 app.include_router(admin_router, prefix="/api/admin")  # Legacy admin routes
 app.include_router(auth_router, prefix="/api/auth", tags=["authentication"])
 app.include_router(admin_auth_router, prefix="/api/auth", tags=["admin-authentication"])  # New JWT admin auth

--- a/backend/migrations/018_add_chat_message_audio_url.py
+++ b/backend/migrations/018_add_chat_message_audio_url.py
@@ -1,0 +1,34 @@
+"""Migration: Add audio_url column to chat_messages table.
+
+Run with: python migrations/018_add_chat_message_audio_url.py
+"""
+
+import os
+import sys
+from sqlalchemy import inspect, text
+
+# Add parent directory to path to import database module
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from database import sync_engine
+
+
+def run_migration() -> None:
+    """Add audio_url column to chat_messages table."""
+    print("Starting migration: Add audio_url to chat_messages...")
+
+    with sync_engine.begin() as conn:
+        inspector = inspect(conn)
+        columns = [col["name"] for col in inspector.get_columns("chat_messages")]
+
+        if "audio_url" not in columns:
+            print("Adding column: audio_url")
+            conn.execute(text("ALTER TABLE chat_messages ADD COLUMN audio_url TEXT"))
+        else:
+            print("Column audio_url already exists, skipping")
+
+    print("✅ Migration completed successfully!")
+
+
+if __name__ == "__main__":
+    run_migration()

--- a/backend/migrations/019_add_chat_message_audio_status.py
+++ b/backend/migrations/019_add_chat_message_audio_status.py
@@ -1,0 +1,40 @@
+"""Migration: Add audio_status and audio_error columns to chat_messages table.
+
+Run with: python migrations/019_add_chat_message_audio_status.py
+"""
+
+import os
+import sys
+from sqlalchemy import inspect, text
+
+# Add parent directory to path to import database module
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from database import sync_engine
+
+
+def run_migration() -> None:
+    """Add audio_status and audio_error columns to chat_messages table."""
+    print("Starting migration: Add audio_status/audio_error to chat_messages...")
+
+    with sync_engine.begin() as conn:
+        inspector = inspect(conn)
+        columns = {col["name"] for col in inspector.get_columns("chat_messages")}
+
+        if "audio_status" not in columns:
+            print("Adding column: audio_status")
+            conn.execute(text("ALTER TABLE chat_messages ADD COLUMN audio_status VARCHAR(32)"))
+        else:
+            print("Column audio_status already exists, skipping")
+
+        if "audio_error" not in columns:
+            print("Adding column: audio_error")
+            conn.execute(text("ALTER TABLE chat_messages ADD COLUMN audio_error TEXT"))
+        else:
+            print("Column audio_error already exists, skipping")
+
+    print("✅ Migration completed successfully!")
+
+
+if __name__ == "__main__":
+    run_migration()

--- a/backend/models.py
+++ b/backend/models.py
@@ -181,6 +181,9 @@ class ChatMessage(Base):
     role = Column(String(50), nullable=False)  # 'user' or 'assistant'
     content = Column(String(10000), nullable=False)  # 10KB limit to prevent DoS attacks
     state_snapshot = Column(Text, nullable=True)
+    audio_url = Column(Text, nullable=True)
+    audio_status = Column(String(32), nullable=True)
+    audio_error = Column(Text, nullable=True)
     timestamp = Column(DateTime, default=func.now())
 
     # Relationships

--- a/backend/prompts/__init__.py
+++ b/backend/prompts/__init__.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from .tts_prompt import build_tts_prompt
+
 
 @dataclass
 class PromptBundle:
@@ -9,4 +11,4 @@ class PromptBundle:
     user_prompt: str
 
 
-__all__ = ["PromptBundle"]
+__all__ = ["PromptBundle", "build_tts_prompt"]

--- a/backend/prompts/tts_prompt.py
+++ b/backend/prompts/tts_prompt.py
@@ -1,0 +1,124 @@
+"""Prompt builder for Gemini TTS generation."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+def _extract_dialogue(text: str) -> list[str]:
+    if not text:
+        return []
+
+    matches: list[tuple[int, str]] = []
+    patterns = [
+        re.compile(r"“([^”]+)”", re.DOTALL),
+        re.compile(r"\"([^\"]+)\"", re.DOTALL),
+    ]
+
+    for pattern in patterns:
+        for match in pattern.finditer(text):
+            segment = match.group(1).strip()
+            if segment:
+                matches.append((match.start(), segment))
+
+    if not matches:
+        return []
+
+    matches.sort(key=lambda item: item[0])
+    return [segment for _, segment in matches]
+
+
+def _strip_state_update(text: str) -> str:
+    if not text:
+        return ""
+    pattern = r"\[\[STATE_UPDATE\]\].*?\[\[/STATE_UPDATE\]\]"
+    cleaned = re.sub(pattern, "", text, flags=re.DOTALL).strip()
+    if "[[STATE_UPDATE]]" in cleaned:
+        cleaned = cleaned.split("[[STATE_UPDATE]]", 1)[0].strip()
+    return cleaned
+
+
+def build_tts_prompt(
+    text: str,
+    *,
+    character_name: Optional[str] = None,
+    voice_style: Optional[str] = None,
+    conversation_style: Optional[str] = None,
+    gender: Optional[str] = None,
+    nsfw_level: Optional[int] = None,
+    tone_hints: Optional[list[str]] = None,
+    dialogue_only: bool = True,
+) -> str:
+    """Build a TTS prompt that preserves the original text."""
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return ""
+
+    content = _strip_state_update(cleaned)
+    if dialogue_only:
+        dialogue = _extract_dialogue(content)
+        if dialogue:
+            content = "\n\n".join(dialogue)
+
+    style_descriptor = "，".join(
+        part
+        for part in [
+            voice_style.strip() if voice_style else "",
+            conversation_style.strip() if conversation_style else "",
+        ]
+        if part
+    )
+
+    tone_lines: list[str] = []
+    if nsfw_level and nsfw_level > 0:
+        gender_value = (gender or "").strip().lower()
+        female_tokens = {"female", "woman", "girl", "f", "女", "女性", "女生"}
+        male_tokens = {"male", "man", "boy", "m", "男", "男性", "男生"}
+
+        if gender_value in male_tokens:
+            tone_lines = [
+                "语速：快，停顿短促但有张力",
+                "音色：温暖、亲近、清晰、带轻微磁性",
+                "情绪：暧昧、挑逗、带强烈吸引力",
+                "呼吸：气息更重，带轻微喘息感",
+            ]
+        else:
+            tone_lines = [
+                "语速：快，断句更勾人，停顿短促带情绪",
+                "音色：低哑、亲密、带气息感，贴近但吐字清晰",
+                "情绪：暧昧、挑逗、带强烈吸引力",
+                "呼吸：带轻微喘息感，气息更热",
+            ]
+    else:
+        tone_lines = [
+            "语速：快，吐字清晰，不拖音",
+            "音色：自然、有温度",
+            "情绪：自然、友好、专注",
+        ]
+
+    if tone_hints:
+        cleaned_hints = [hint.strip() for hint in tone_hints if hint and hint.strip()]
+        if cleaned_hints:
+            tone_lines.append("动态提示：" + "；".join(cleaned_hints[:2]))
+
+    header_lines: list[str] = ["# DIRECTOR'S NOTES"]
+    if character_name:
+        header_lines.insert(0, f"# AUDIO PROFILE\n角色：{character_name}")
+        if style_descriptor:
+            header_lines.insert(1, f"风格：{style_descriptor}")
+    elif style_descriptor:
+        header_lines.insert(1, f"风格：{style_descriptor}")
+
+    prompt_sections = [
+        "\n".join(header_lines),
+        "\n".join(tone_lines),
+        "",
+        "# TRANSCRIPT",
+        content,
+    ]
+
+    return "\n".join(prompt_sections)
+
+
+__all__ = ["build_tts_prompt"]

--- a/backend/routes/tts_routes.py
+++ b/backend/routes/tts_routes.py
@@ -1,0 +1,312 @@
+"""TTS Routes for generating speech audio from AI chat messages."""
+
+import json
+import logging
+import os
+from typing import Optional
+
+import anyio
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.routes import get_current_user
+from config import settings
+from google.genai import types
+from database import SessionLocal, get_async_db
+from models import Chat, ChatMessage, Character, User
+from payment.token_service import TokenService
+from prompts.tts_prompt import build_tts_prompt
+from services.gemini_service_new import GeminiService, AIServiceError
+from services.upload_service import UploadService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/chat/messages", tags=["tts"])
+
+TTS_TOKEN_COST = 20
+TTS_BLOCKED_STATUS = "blocked"
+TTS_READY_STATUS = "ready"
+TTS_FAILED_STATUS = "failed"
+
+
+def _parse_state_snapshot(raw_snapshot: Optional[str]) -> dict:
+    if not raw_snapshot:
+        return {}
+    try:
+        parsed = json.loads(raw_snapshot)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    if isinstance(parsed, dict):
+        return parsed
+    return {}
+
+
+def _normalize_state_value(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    if value <= 0:
+        return 0.0
+    if value <= 1:
+        return min(1.0, value)
+    if value <= 10:
+        return value / 10
+    if value <= 100:
+        return value / 100
+    return min(1.0, value / 100)
+
+
+def _read_state_number(snapshot: dict, key: str) -> Optional[float]:
+    value = snapshot.get(key)
+    if isinstance(value, dict):
+        raw = value.get("value")
+        if isinstance(raw, (int, float)):
+            return _normalize_state_value(float(raw))
+        return None
+    if isinstance(value, (int, float)):
+        return _normalize_state_value(float(value))
+    return None
+
+
+def _read_state_text(snapshot: dict, key: str) -> Optional[str]:
+    value = snapshot.get(key)
+    if isinstance(value, dict):
+        raw = value.get("description") or value.get("value")
+        if isinstance(raw, str):
+            return raw.strip()
+        return None
+    if isinstance(value, str):
+        return value.strip()
+    return None
+
+
+def _derive_tone_hints(snapshot: dict, character: Optional[Character]) -> list[str]:
+    hints: list[str] = []
+
+    def add_hint(text: str) -> None:
+        normalized = text.strip()
+        if normalized and normalized not in hints:
+            hints.append(normalized)
+
+    for key in ("语气", "情绪"):
+        text_hint = _read_state_text(snapshot, key)
+        if text_hint:
+            add_hint(text_hint)
+
+    excitement = _read_state_number(snapshot, "兴奋度")
+    desire = _read_state_number(snapshot, "欲望值")
+    fatigue = _read_state_number(snapshot, "疲惫度")
+    trust = _read_state_number(snapshot, "信任度")
+    favor = _read_state_number(snapshot, "好感度")
+
+    if excitement is not None and excitement >= 0.7:
+        add_hint("兴奋、娇喘更明显、语速略快、声线更黏")
+    if desire is not None and desire >= 0.7:
+        add_hint("欲望强烈、低哑、喘息明显、挑逗")
+    if fatigue is not None and fatigue >= 0.7:
+        add_hint("慵懒、气息更轻")
+    if trust is not None and trust >= 0.7:
+        add_hint("亲密、依恋、语气更软")
+    if favor is not None and favor >= 0.7:
+        add_hint("撒娇、黏人、亲昵")
+
+    if character and getattr(character, "nsfw_level", 0) > 0:
+        add_hint("语气淫靡、性感、露骨挑逗")
+
+    return hints
+
+
+def _select_voice_name(character: Optional[Character]) -> Optional[str]:
+    env_default = os.getenv("GEMINI_TTS_VOICE", "").strip()
+    if env_default:
+        return env_default
+
+    if not character or not getattr(character, "gender", None):
+        return None
+
+    gender = str(character.gender).strip().lower()
+    age_value = getattr(character, "age", None)
+    mature_threshold_raw = os.getenv("GEMINI_TTS_MATURE_AGE", "30").strip()
+    try:
+        mature_threshold = int(mature_threshold_raw)
+    except ValueError:
+        mature_threshold = 30
+    is_mature = isinstance(age_value, int) and age_value >= mature_threshold
+
+    female_tokens = {"female", "woman", "girl", "f", "女", "女性", "女生"}
+    male_tokens = {"male", "man", "boy", "m", "男", "男性", "男生"}
+    neutral_tokens = {"neutral", "non-binary", "nb", "中性", "未知"}
+
+    if gender in female_tokens:
+        return "Gacrux" if is_mature else "Kore"
+    if gender in male_tokens:
+        return "Algieba" if is_mature else "Schedar"
+    if gender in neutral_tokens:
+        return "Schedar"
+    return None
+
+
+def _build_tts_safety_settings(
+    character: Optional[Character],
+) -> Optional[list[types.SafetySetting]]:
+    raw_flag = os.getenv("GEMINI_TTS_ALLOW_NSFW", "").strip().lower()
+    if raw_flag in {"0", "false", "no"}:
+        return None
+    allow_nsfw = True if raw_flag == "" else raw_flag in {"1", "true", "yes"}
+    if not allow_nsfw:
+        return None
+    if not character or getattr(character, "nsfw_level", 0) <= 0:
+        return None
+
+    return [
+        types.SafetySetting(
+            category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+            threshold=types.HarmBlockThreshold.BLOCK_NONE,
+        )
+    ]
+
+
+def _is_tts_blocked_error(error_text: str) -> bool:
+    if not error_text:
+        return False
+    lowered = error_text.lower()
+    return any(
+        token in lowered
+        for token in (
+            "blocked",
+            "prohibited_content",
+            "blocklist",
+            "safety",
+        )
+    )
+
+
+async def _has_sufficient_tokens(user_id: int, amount: int) -> bool:
+    def _worker() -> bool:
+        with SessionLocal() as sync_session:
+            token_service = TokenService(sync_session)
+            return token_service.has_sufficient_balance(user_id, amount)
+
+    return await anyio.to_thread.run_sync(_worker)
+
+
+async def _deduct_tokens(user_id: int, amount: int, description: str) -> bool:
+    def _worker() -> bool:
+        with SessionLocal() as sync_session:
+            token_service = TokenService(sync_session)
+            return token_service.deduct_tokens(user_id, amount, description)
+
+    return await anyio.to_thread.run_sync(_worker)
+
+
+@router.post("/{message_id}/tts")
+async def generate_message_tts(
+    message_id: int,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Generate TTS audio for a specific AI chat message."""
+    stmt = select(ChatMessage).where(
+        ChatMessage.id == message_id,
+        ChatMessage.user_id == current_user.id,
+    )
+    message = (await db.execute(stmt)).scalars().first()
+    if not message:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    if message.role != "assistant":
+        raise HTTPException(status_code=400, detail="TTS is only available for AI messages")
+
+    if message.audio_url:
+        if message.audio_status != TTS_READY_STATUS or message.audio_error:
+            message.audio_status = TTS_READY_STATUS
+            message.audio_error = None
+            await db.commit()
+        return {"audioUrl": message.audio_url}
+
+    if message.audio_status == TTS_BLOCKED_STATUS:
+        detail = message.audio_error or "TTS blocked for this response"
+        raise HTTPException(status_code=422, detail=detail)
+
+    if not await _has_sufficient_tokens(current_user.id, TTS_TOKEN_COST):
+        raise HTTPException(status_code=402, detail="Insufficient tokens")
+
+    gemini_service = GeminiService(api_key=settings.gemini_api_key)
+    await gemini_service.initialize()
+    if not gemini_service.is_available:
+        raise HTTPException(status_code=503, detail="Gemini TTS unavailable")
+
+    character = None
+    if message.chat_id:
+        chat = await db.get(Chat, message.chat_id)
+        if chat:
+            character = await db.get(Character, chat.character_id)
+
+    tts_prompt = build_tts_prompt(
+        message.content,
+        character_name=getattr(character, "name", None) if character else None,
+        voice_style=getattr(character, "voice_style", None) if character else None,
+        conversation_style=getattr(character, "conversation_style", None) if character else None,
+        gender=getattr(character, "gender", None) if character else None,
+        nsfw_level=getattr(character, "nsfw_level", None) if character else None,
+        tone_hints=_derive_tone_hints(
+            _parse_state_snapshot(message.state_snapshot),
+            character,
+        ),
+    )
+    safety_settings = _build_tts_safety_settings(character)
+    voice_name = _select_voice_name(character)
+    voice_config = {"voice_name": voice_name} if voice_name else None
+
+    try:
+        audio_bytes = await gemini_service.generate_speech(
+            tts_prompt,
+            voice_config=voice_config,
+            safety_settings=safety_settings,
+        )
+    except AIServiceError as exc:
+        error_text = str(exc)
+        logger.error("Gemini TTS failed for message %s: %s", message_id, error_text)
+        if _is_tts_blocked_error(error_text):
+            message.audio_status = TTS_BLOCKED_STATUS
+            message.audio_error = error_text
+            await db.commit()
+            raise HTTPException(status_code=422, detail="TTS blocked for this response")
+
+        message.audio_status = TTS_FAILED_STATUS
+        message.audio_error = error_text
+        await db.commit()
+        raise HTTPException(status_code=502, detail="TTS generation failed")
+
+    mime_type = gemini_service.last_audio_mime_type or "audio/wav"
+
+    upload_service = UploadService()
+    success, upload_data, error = await upload_service.save_chat_audio(
+        audio_bytes,
+        current_user.id,
+        mime_type=mime_type,
+        message_id=message.id,
+    )
+    if not success:
+        logger.error("Chat audio upload failed for message %s: %s", message_id, error)
+        message.audio_status = TTS_FAILED_STATUS
+        message.audio_error = error or "Failed to store audio"
+        await db.commit()
+        raise HTTPException(status_code=500, detail=error or "Failed to store audio")
+
+    deduction_description = f"TTS generation for message {message_id}"
+    if not await _deduct_tokens(current_user.id, TTS_TOKEN_COST, deduction_description):
+        storage_path = upload_data.get("storagePath") if isinstance(upload_data, dict) else None
+        if storage_path:
+            try:
+                await upload_service.storage.delete_object(storage_path)
+            except Exception as exc:
+                logger.warning("Failed to delete chat audio after token failure: %s", exc)
+        raise HTTPException(status_code=402, detail="Insufficient tokens")
+
+    message.audio_url = upload_data["url"]
+    message.audio_status = TTS_READY_STATUS
+    message.audio_error = None
+    await db.commit()
+
+    return {"audioUrl": message.audio_url}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -260,6 +260,9 @@ class ChatMessage(ChatMessageBase):
     uuid: Optional[UUID] = None  # UUID field for new security model
     timestamp: datetime
     stateSnapshot: Optional[Dict[str, Union[str, Dict[str, Any]]]] = Field(default=None, alias="state_snapshot")
+    audioUrl: Optional[str] = Field(default=None, alias="audio_url")
+    audioStatus: Optional[str] = Field(default=None, alias="audio_status")
+    audioError: Optional[str] = Field(default=None, alias="audio_error")
 
 # API response schemas
 class MessageResponse(BaseSchema):

--- a/backend/services/message_service.py
+++ b/backend/services/message_service.py
@@ -108,6 +108,9 @@ class MessageService:
                     "chat_id": message.chat_id,
                     "role": message.role,
                     "content": message.content,
+                    "audio_url": message.audio_url,
+                    "audio_status": message.audio_status,
+                    "audio_error": message.audio_error,
                     "timestamp": format_datetime(message.timestamp),
                     "state_snapshot": self._filter_snapshot_keys(
                         self._deserialize_state_snapshot(message.state_snapshot),
@@ -149,6 +152,9 @@ class MessageService:
                 "chat_id": message.chat_id,
                 "role": message.role,
                 "content": message.content,
+                "audio_url": message.audio_url,
+                "audio_status": message.audio_status,
+                "audio_error": message.audio_error,
                 "timestamp": format_datetime(message.timestamp),
                 "state_snapshot": self._deserialize_state_snapshot(message.state_snapshot),
             }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -489,6 +489,103 @@
     pointer-events: none;
   }
 
+  .chat-audio-bubble {
+    @apply rounded-[18px] rounded-bl-[4px] px-4 py-3 text-white/90 relative;
+    background: linear-gradient(
+      135deg,
+      rgba(56, 189, 248, 0.3) 0%,
+      rgba(168, 85, 247, 0.28) 50%,
+      rgba(236, 72, 153, 0.25) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    box-shadow:
+      inset 0 1px 1px 0 rgba(255, 255, 255, 0.12),
+      0 6px 20px -6px rgba(56, 189, 248, 0.4);
+  }
+
+  .chat-audio-bubble--playing {
+    box-shadow:
+      inset 0 1px 1px 0 rgba(255, 255, 255, 0.15),
+      0 10px 26px -8px rgba(56, 189, 248, 0.55);
+  }
+
+  .chat-audio-bubble::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.12) 0%,
+      transparent 60%
+    );
+    pointer-events: none;
+  }
+
+  .audio-play-button {
+    @apply flex h-9 w-9 items-center justify-center rounded-full text-white/90 transition;
+    background: rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 4px 10px -4px rgba(15, 23, 42, 0.6);
+  }
+
+  .audio-play-button:hover {
+    background: rgba(15, 23, 42, 0.7);
+  }
+
+  .audio-wave {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 22px;
+  }
+
+  .audio-wave-bar {
+    width: 4px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.82);
+    opacity: 0.7;
+    transform-origin: bottom;
+  }
+
+  .audio-wave-bar--playing {
+    animation: audioWave 1.2s ease-in-out infinite;
+    opacity: 0.9;
+  }
+
+  .audio-progress {
+    margin-top: 6px;
+    height: 3px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.28);
+    overflow: hidden;
+  }
+
+  .audio-progress__fill {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(
+      90deg,
+      rgba(125, 211, 252, 0.9) 0%,
+      rgba(244, 114, 182, 0.8) 100%
+    );
+    transition: width 0.2s ease-out;
+  }
+
+  .chat-audio-bubble--playing .audio-progress__fill {
+    box-shadow: 0 0 8px rgba(125, 211, 252, 0.5);
+  }
+
+  @keyframes audioWave {
+    0%,
+    100% {
+      transform: scaleY(0.6);
+    }
+    50% {
+      transform: scaleY(1.2);
+    }
+  }
+
   .chat-bubble-user {
     @apply rounded-[18px] rounded-br-[4px] p-3 text-white relative;
     background: linear-gradient(

--- a/client/src/lib/chatApi.ts
+++ b/client/src/lib/chatApi.ts
@@ -49,3 +49,13 @@ export async function requestChatGeneration(
     throw err;
   }
 }
+
+export async function requestMessageTts(
+  messageId: number,
+): Promise<{ audioUrl: string }> {
+  const response = await apiRequest(
+    "POST",
+    `/api/chat/messages/${messageId}/tts`,
+  );
+  return (await response.json()) as { audioUrl: string };
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -61,6 +61,12 @@ export interface ChatMessage {
   chatId: number;
   role: "user" | "assistant" | "system";
   content: string;
+  audioUrl?: string;
+  audio_url?: string;
+  audioStatus?: string;
+  audio_status?: string;
+  audioError?: string;
+  audio_error?: string;
   timestamp?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- add TTS route + prompt builder
  with voice mapping and safety handling
- persist audio_url/audio_status/audio_error and include in API payloads
- upload chat audio
  then deduct tokens; handle blocked/failed cases
- add audio bubble UI with playback controls and blocked-state UX
- strip
  [[STATE_UPDATE]] tags from visible content and treat AI fallback as non-billable error

## Testing
- not run (local/manual only)
