### PR TITLE
feat(characters): versioned Scene Bundle migration (#272)

### DIFF
--- a/backend/migrations/021_add_character_scene_bundle_metadata.py
+++ b/backend/migrations/021_add_character_scene_bundle_metadata.py
@@ -1,0 +1,132 @@
+"""
+Migration 021: Character Scene Bundle metadata (Issue #272).
+
+Adds:
+- scene_summary: atomic bundle one-line summary
+- scenario_hook: replaceable current-scene input (not baked into persona core)
+- generation_version: content pipeline version marker
+- source_hash: hash of persona_prompt + scenario_hook (+ related inputs)
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import text
+
+PARENT_DIR = Path(__file__).resolve().parent.parent
+if str(PARENT_DIR) not in sys.path:
+    sys.path.insert(0, str(PARENT_DIR))
+
+load_dotenv()
+
+try:
+    from database import sync_engine as engine
+    from models import Base
+except ImportError:
+    from backend.database import sync_engine as engine  # fallback
+    from backend.models import Base
+
+logger = logging.getLogger(__name__)
+
+COLUMNS = (
+    ("scene_summary", "TEXT"),
+    ("scenario_hook", "TEXT"),
+    ("generation_version", "VARCHAR(32)"),
+    ("source_hash", "VARCHAR(64)"),
+)
+
+
+def column_exists(conn, table: str, column: str) -> bool:
+    query = text(
+        """
+        SELECT 1
+        FROM pragma_table_info(:table)
+        WHERE name = :column
+        """
+        if conn.dialect.name == "sqlite"
+        else """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = :table
+          AND column_name = :column
+        """
+    )
+    return conn.execute(query, {"table": table, "column": column}).first() is not None
+
+
+def run_migration() -> bool:
+    try:
+        Base.metadata.create_all(engine)
+
+        with engine.connect() as conn:
+            trans = conn.begin()
+            try:
+                dialect = conn.dialect.name
+                logger.info("Running migration 021 (dialect=%s)...", dialect)
+
+                for name, col_type in COLUMNS:
+                    if column_exists(conn, "characters", name):
+                        logger.info("Column %s already exists; skipping.", name)
+                        continue
+                    logger.info("Adding characters.%s ...", name)
+                    conn.execute(
+                        text(f"ALTER TABLE characters ADD COLUMN {name} {col_type}")
+                    )
+                    logger.info("Added characters.%s", name)
+
+                if dialect != "sqlite":
+                    conn.execute(
+                        text(
+                            "CREATE INDEX IF NOT EXISTS idx_characters_generation_version "
+                            "ON characters (generation_version)"
+                        )
+                    )
+
+                trans.commit()
+                logger.info("Migration 021 applied successfully.")
+                return True
+            except Exception as exc:
+                logger.error("Migration 021 failed; rolling back: %s", exc)
+                trans.rollback()
+                raise
+    except Exception as exc:
+        logger.error("Migration 021 error: %s", exc)
+        return False
+
+
+def downgrade() -> bool:
+    try:
+        with engine.connect() as conn:
+            trans = conn.begin()
+            try:
+                dialect = conn.dialect.name
+                if dialect == "sqlite":
+                    logger.warning(
+                        "SQLite cannot drop columns without rebuild; leaving columns in place."
+                    )
+                else:
+                    conn.execute(text("DROP INDEX IF EXISTS idx_characters_generation_version"))
+                    for name, _ in COLUMNS:
+                        if column_exists(conn, "characters", name):
+                            conn.execute(text(f"ALTER TABLE characters DROP COLUMN {name}"))
+                            logger.info("Dropped characters.%s", name)
+                trans.commit()
+                return True
+            except Exception as exc:
+                logger.error("Downgrade 021 failed: %s", exc)
+                trans.rollback()
+                raise
+    except Exception as exc:
+        logger.error("Downgrade 021 error: %s", exc)
+        return False
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    if run_migration():
+        logger.info("Migration 021 finished successfully.")
+    else:
+        logger.error("Migration 021 failed.")
+        sys.exit(1)

--- a/backend/models.py
+++ b/backend/models.py
@@ -75,9 +75,14 @@ class Character(Base):
     description = Column(Text, nullable=True)  # Short description
     opening_line = Column(Text, nullable=True)  # Cached chat opener
     default_state_json = Column(Text, nullable=True)  # Cached state seed template
+    # Issue #272: versioned Scene Bundle metadata + replaceable scenario
+    scene_summary = Column(Text, nullable=True)  # Atomic bundle summary (with opening+state)
+    scenario_hook = Column(Text, nullable=True)  # Replaceable current-scene input (not persona core)
+    generation_version = Column(String(32), nullable=True)  # e.g. scene_bundle_v1
+    source_hash = Column(String(64), nullable=True)  # Hash of persona+hook inputs
     avatar_url = Column(String(500), nullable=True)  # Keep for backward compatibility
     backstory = Column(Text, nullable=False)
-    persona_prompt = Column(Text, nullable=True)  # Optional persona prompt that overrides backstory for LLM
+    persona_prompt = Column(Text, nullable=True)  # Stable character core + short Dynamics
     voice_style = Column(String(500), nullable=False)
     traits = Column(JSON, nullable=False)  # List of strings
     personality_traits = Column(JSON, nullable=True)  # Deprecated - keeping for backward compatibility

--- a/backend/prompts/scene_bootstrap.py
+++ b/backend/prompts/scene_bootstrap.py
@@ -17,19 +17,28 @@ def build_scene_bootstrap_prompt(
     safe_mode: bool,
     state_keys: Sequence[str],
     language: str = "zh",
+    scenario_hook: str = "",
 ) -> PromptBundle:
     """
     Build a single prompt that returns opening_line + state for ONE shared scene.
 
     This replaces independent opening / state-seed calls that drift apart.
+    persona_text should be the stable character core; scenario_hook is the
+    replaceable current-scene input (kitchen / living room / nightclub / …).
     """
     name = (character_name or "角色").strip()
     description = (description or "").strip() or "（暂无简介）"
     persona_text = (persona_text or "").strip() or "（暂无补充人设）"
     voice_style = (voice_style or "").strip() or "（未指定）"
+    scenario_hook = (scenario_hook or "").strip()
     key_list = ", ".join(state_keys)
 
     if language == "en":
+        scenario_block = (
+            f"Current scenario hook (replaceable — use THIS as the opening place/situation):\n{scenario_hook}\n"
+            if scenario_hook
+            else "Current scenario hook: (not provided — extract ONE present opening beat from persona; do not bake it back into the character core)\n"
+        )
         system_instruction = dedent(
             f"""
             You are a roleplay scene director. From the character materials, invent ONE coherent
@@ -46,8 +55,8 @@ def build_scene_bootstrap_prompt(
 
             Hard rules:
             1. opening_line and state (especially environment / clothes / posture) MUST describe the SAME present moment.
-            2. Pick ONE present starting beat. If persona mixes long backstory with a current crisis, choose the present beat the user joins — do not summarize the whole plot.
-            3. Do not invent bondage / prison / aphrodisiac / extreme NSFW as CURRENT state unless persona clearly frames that as the starting situation.
+            2. Prefer the scenario_hook as the present beat when provided. Persona is identity/dynamics only — do not permanently relocate the character into dungeon/kitchen/etc. unless the hook says so.
+            3. Do not invent bondage / prison / aphrodisiac / extreme NSFW as CURRENT state unless persona or scenario_hook clearly frames that as the starting situation.
             4. First-meeting affinity (好感度) is usually 4–6 unless the opening premise is enmity/captivity hostility.
             5. Voice must match the character; witty characters should sound witty, not generic flirt templates.
             6. state MUST include EVERY listed key. Descriptive fields (环境, 衣服/衣着, 姿势/仪态, etc.) must be non-empty prose — never omit, never empty string.
@@ -59,15 +68,21 @@ def build_scene_bootstrap_prompt(
             Character name: {name}
             Public description: {description}
             Voice style: {voice_style}
-            Persona / backstory (may include plot — extract ONE present opening scene):
+            Stable persona / dynamics (identity only — not a locked location):
             {persona_text}
 
+            {scenario_block}
             Mode: {"SAFE (non-explicit)" if safe_mode else "NSFW-capable (can be sensual if persona warrants it)"}
 
             Return the JSON object now.
             """
         ).strip()
     else:
+        scenario_block = (
+            f"【当前场景钩子 scenario_hook｜可替换】\n{scenario_hook}\n"
+            if scenario_hook
+            else "【当前场景钩子】未提供——请从人设中抽取一个「现在时」开场；不要把地点永久写回角色核。\n"
+        )
         system_instruction = dedent(
             f"""
             你是角色扮演的场景导演。根据角色材料，只选定【一个】用户走进时的开场现场，
@@ -83,8 +98,8 @@ def build_scene_bootstrap_prompt(
 
             硬性规则：
             1. opening_line 与 state（尤其 环境 / 衣服或衣着 / 姿势或仪态）必须是同一当下。
-            2. 只选一个「现在时」开场节拍。若人设混有长篇背景与当前危机，取用户走进时的当下，不要复述整段剧情。
-            3. 除非人设明确把捆绑/地牢/春药/极端 NSFW 写成【开场当下】，否则不要把它们写进当前 state。
+            2. 若提供了 scenario_hook，必须以它为开场地点/情境；persona 只提供身份与动力学，不要把地牢/厨房/客厅等可替换场景永久写进角色核。
+            3. 除非人设或 scenario_hook 明确把捆绑/地牢/春药/极端 NSFW 写成【开场当下】，否则不要把它们写进当前 state。
             4. 初次见面好感度通常 4–6；仅当开场前提就是敌对/俘获敌意时才可更低。
             5. 语气必须像这个角色（机智角色要有机锋），禁止通用调情模板。
             6. state 必须包含上面列出的【每一个】键；描述字段（环境、衣服/衣着、姿势/仪态等）必须是非空中文句子，禁止省略、禁止空字符串。
@@ -96,9 +111,10 @@ def build_scene_bootstrap_prompt(
             角色名：{name}
             对外简介：{description}
             说话方式：{voice_style}
-            人设/背景（可能含剧情——请抽取一个开场当下）：
+            稳定人设/动力学（身份核，不是锁死地点）：
             {persona_text}
 
+            {scenario_block}
             模式：{"SAFE（非露骨）" if safe_mode else "NSFW 可用（人设需要时可以暧昧/情欲，但仍须场景自洽）"}
 
             现在输出 JSON。
@@ -144,6 +160,40 @@ def scene_pair_looks_coherent(opening_line: str, state: dict, *, safe_mode: bool
 
 
 QUANTIFIABLE_KEYS = {"情绪", "好感度", "信任度", "兴奋度", "疲惫度", "欲望值", "敏感度"}
+
+# Known soft-fallback templates — must never pass atomic migration validation.
+GENERIC_FALLBACK_ENV_MARKERS = (
+    "私密空间光线暖柔",
+    "温暖明亮的室内空间",
+    "Warm, well-lit indoor",
+    "Private space with warm soft light",
+)
+
+_PLACE_MARKERS = (
+    "厨房",
+    "客厅",
+    "夜店",
+    "吧台",
+    "营帐",
+    "洞府",
+    "办公室",
+    "画室",
+    "卧室",
+    "书房",
+    "车站",
+    "桃花",
+    "庭院",
+    "地牢",
+    "牢房",
+    "酒吧",
+    "浴室",
+    "阳台",
+)
+
+
+def place_markers(text: str) -> set:
+    body = text or ""
+    return {m for m in _PLACE_MARKERS if m in body}
 
 
 def _normalize_quantified_value(value):
@@ -233,8 +283,11 @@ def parse_scene_bootstrap_response(text, allowed_keys):
 
 
 __all__ = [
+    "GENERIC_FALLBACK_ENV_MARKERS",
+    "QUANTIFIABLE_KEYS",
     "build_scene_bootstrap_prompt",
-    "scene_pair_looks_coherent",
     "parse_scene_bootstrap_response",
     "parse_state_fields",
+    "place_markers",
+    "scene_pair_looks_coherent",
 ]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -120,6 +120,10 @@ class Character(CharacterBase):
     createdAt: datetime = Field(alias="created_at")  # Map database field to frontend field
     openingLine: Optional[str] = Field(default=None, alias="opening_line")
     defaultState: Optional[Dict[str, Union[str, Dict[str, Any]]]] = Field(default=None, alias="default_state_json")
+    sceneSummary: Optional[str] = Field(default=None, alias="scene_summary")
+    scenarioHook: Optional[str] = Field(default=None, alias="scenario_hook")
+    generationVersion: Optional[str] = Field(default=None, alias="generation_version")
+    sourceHash: Optional[str] = Field(default=None, alias="source_hash")
 
     # Admin management and analytics fields
     isFeatured: bool = Field(default=False, alias="is_featured")

--- a/backend/scripts/migrate_scene_bundles.py
+++ b/backend/scripts/migrate_scene_bundles.py
@@ -1,0 +1,365 @@
+"""Migrate legacy characters to versioned Scene Bundles (Issue #272).
+
+Defaults to dry-run. Writes only with explicit --apply after validation.
+
+Examples:
+  # Audit + generate candidates for 12 featured characters (no DB writes)
+  python scripts/migrate_scene_bundles.py --featured
+
+  # Specific IDs
+  python scripts/migrate_scene_bundles.py --ids 4,13,67,71,73
+
+  # After review, apply validated candidates only
+  python scripts/migrate_scene_bundles.py --featured --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from database import SessionLocal
+from services.scene_bundle_migrator import SceneBundleMigrator, select_characters
+from utils.character_content_version import SCENE_BUNDLE_GENERATION_VERSION
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_ids(raw: Optional[str]) -> Optional[List[int]]:
+    if not raw:
+        return None
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return [int(p) for p in parts]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Migrate characters to versioned atomic Scene Bundles (default: dry-run)."
+    )
+    parser.add_argument(
+        "--ids",
+        type=str,
+        default="",
+        help="Comma-separated character IDs to process.",
+    )
+    parser.add_argument(
+        "--featured",
+        action="store_true",
+        help="Process featured characters only.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum characters to process (0 = all matched).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Regenerate even when generation_version+source_hash already match.",
+    )
+    parser.add_argument(
+        "--audit-only",
+        action="store_true",
+        help="Only separate persona/scenario and print old vs proposed core (no AI Scene Bundle).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write validated candidates to the database. Without this flag, dry-run only.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="",
+        help="Optional path to write JSON report (defaults under backend/tmp/).",
+    )
+    parser.add_argument(
+        "--generation-version",
+        type=str,
+        default=SCENE_BUNDLE_GENERATION_VERSION,
+        help="Target generation_version stamp.",
+    )
+    return parser.parse_args()
+
+
+def _preview_text(value: Optional[str], limit: int = 160) -> str:
+    text = (value or "").replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _print_candidate(candidate) -> None:
+    header = f"[{candidate.character_id}] {candidate.name}"
+    if candidate.skipped:
+        logger.info("%s SKIP — %s", header, candidate.skip_reason)
+        return
+    status = "OK" if candidate.validation_ok else "FAIL"
+    logger.info("%s %s", header, status)
+    if candidate.validation_errors:
+        logger.info("  errors: %s", "; ".join(candidate.validation_errors))
+    audit = candidate.audit or {}
+    logger.info(
+        "  audit: dynamics=%s persona_len=%s scene_locks=%s",
+        audit.get("has_explicit_dynamics"),
+        audit.get("persona_len"),
+        audit.get("scene_lock_hints"),
+    )
+    old = candidate.old or {}
+    new = candidate.new or {}
+    logger.info("  OLD opening: %s", _preview_text(old.get("opening_line")))
+    logger.info("  NEW opening: %s", _preview_text(new.get("opening_line")))
+    logger.info("  OLD scene_summary: %s", _preview_text(old.get("scene_summary")))
+    logger.info("  NEW scene_summary: %s", _preview_text(new.get("scene_summary")))
+    logger.info("  NEW scenario_hook: %s", _preview_text(new.get("scenario_hook"), 200))
+    old_env = (old.get("default_state") or {}).get("环境")
+    new_env = (new.get("default_state") or {}).get("环境")
+    logger.info("  OLD 环境: %s", _preview_text(str(old_env or "")))
+    logger.info("  NEW 环境: %s", _preview_text(str(new_env or "")))
+    logger.info(
+        "  meta: version=%s hash=%s",
+        new.get("generation_version"),
+        _preview_text(new.get("source_hash"), 16),
+    )
+
+
+async def run_audit_only(
+    *,
+    character_ids: Optional[Sequence[int]],
+    featured_only: bool,
+    limit: int,
+    output_path: str,
+) -> int:
+    """Persona/scenario separation preview without calling the LLM."""
+    from services.scene_bundle_migrator import snapshot_character_content
+    from utils.persona_scenario_split import migration_audit_flags, separate_persona_and_scenario
+    from utils.character_content_version import (
+        SCENE_BUNDLE_GENERATION_VERSION,
+        character_needs_regeneration,
+        compute_source_hash,
+    )
+
+    session = SessionLocal()
+    report = {
+        "mode": "audit-only",
+        "generation_version": SCENE_BUNDLE_GENERATION_VERSION,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "candidates": [],
+        "summary": {},
+    }
+    try:
+        characters = select_characters(
+            session,
+            character_ids=character_ids,
+            featured_only=featured_only,
+            limit=limit,
+        )
+        logger.info("Auditing %d character(s)...", len(characters))
+        needs = 0
+        for character in characters:
+            persona, hook = separate_persona_and_scenario(character)
+            audit = migration_audit_flags(character)
+            stale = character_needs_regeneration(
+                character,
+                persona_prompt=persona,
+                scenario_hook=hook,
+            )
+            if stale:
+                needs += 1
+            entry = {
+                "character_id": character.id,
+                "name": character.name,
+                "needs_regeneration": stale,
+                "audit": audit,
+                "old": snapshot_character_content(character),
+                "proposed": {
+                    "persona_prompt": persona,
+                    "scenario_hook": hook,
+                    "generation_version": SCENE_BUNDLE_GENERATION_VERSION,
+                    "source_hash": compute_source_hash(
+                        name=character.name or "",
+                        description=character.description or "",
+                        persona_prompt=persona,
+                        scenario_hook=hook,
+                        voice_style=character.voice_style or "",
+                        nsfw_level=int(character.nsfw_level or 0),
+                    ),
+                },
+            }
+            report["candidates"].append(entry)
+            logger.info(
+                "[%s] %s needs_regen=%s dynamics=%s persona %s→%s locks=%s",
+                character.id,
+                character.name,
+                stale,
+                audit.get("has_explicit_dynamics"),
+                audit.get("persona_len"),
+                len(persona),
+                audit.get("scene_lock_hints"),
+            )
+            logger.info("  scenario_hook: %s", _preview_text(hook, 200))
+            logger.info("  OLD opening: %s", _preview_text(entry["old"].get("opening_line")))
+        report["summary"] = {
+            "matched": len(characters),
+            "needs_regeneration": needs,
+        }
+    finally:
+        session.close()
+
+    out = Path(output_path) if output_path else Path("tmp") / (
+        f"scene_bundle_audit_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    logger.info("Wrote audit report: %s", out)
+    return 0
+
+
+async def run_migration(
+    *,
+    character_ids: Optional[Sequence[int]],
+    featured_only: bool,
+    limit: int,
+    force: bool,
+    apply: bool,
+    output_path: str,
+    generation_version: str,
+    audit_only: bool = False,
+) -> int:
+    if audit_only:
+        if apply:
+            logger.error("--audit-only cannot be combined with --apply")
+            return 1
+        return await run_audit_only(
+            character_ids=character_ids,
+            featured_only=featured_only,
+            limit=limit,
+            output_path=output_path,
+        )
+
+    if apply:
+        logger.warning("APPLY MODE — validated candidates will be written to the database.")
+    else:
+        logger.info("DRY-RUN mode — no database writes (pass --apply to write).")
+
+    from services.ai_model_manager import AIModelManager
+
+    manager = AIModelManager()
+    initialized = await manager.initialize()
+    if not initialized:
+        logger.error("No AI providers available; cannot generate atomic Scene Bundles.")
+        return 1
+
+    migrator = SceneBundleMigrator(
+        ai_manager=manager,
+        generation_version=generation_version,
+        force=force,
+    )
+
+    session = SessionLocal()
+    report = {
+        "mode": "apply" if apply else "dry-run",
+        "generation_version": generation_version,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "candidates": [],
+        "summary": {},
+    }
+
+    try:
+        characters = select_characters(
+            session,
+            character_ids=character_ids,
+            featured_only=featured_only,
+            limit=limit,
+        )
+        if not characters:
+            logger.warning("No characters matched selection filters.")
+            report["summary"] = {"matched": 0}
+            return 0
+
+        logger.info("Processing %d character(s)...", len(characters))
+        ok = fail = skipped = applied = 0
+
+        for character in characters:
+            candidate = await migrator.build_candidate(character)
+            _print_candidate(candidate)
+            report["candidates"].append(candidate.to_dict())
+
+            if candidate.skipped:
+                skipped += 1
+                continue
+            if not candidate.validation_ok:
+                fail += 1
+                continue
+            ok += 1
+            if apply:
+                if migrator.apply_candidate(character, candidate):
+                    session.add(character)
+                    session.commit()
+                    applied += 1
+                    logger.info("  applied id=%s", character.id)
+                else:
+                    session.rollback()
+                    fail += 1
+                    ok -= 1
+
+        report["summary"] = {
+            "matched": len(characters),
+            "validation_ok": ok,
+            "validation_failed": fail,
+            "skipped_idempotent": skipped,
+            "applied": applied if apply else 0,
+        }
+        logger.info("Summary: %s", report["summary"])
+    finally:
+        session.close()
+
+    out = Path(output_path) if output_path else Path("tmp") / (
+        f"scene_bundle_migration_{'apply' if apply else 'dryrun'}_"
+        f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    logger.info("Wrote report: %s", out)
+    return 0 if report["summary"].get("validation_failed", 0) == 0 else 2
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    args = _parse_args()
+    ids = _parse_ids(args.ids)
+    if not ids and not args.featured and args.limit <= 0:
+        logger.error("Specify --featured, --ids, or --limit to select characters.")
+        sys.exit(1)
+
+    code = asyncio.run(
+        run_migration(
+            character_ids=ids,
+            featured_only=args.featured,
+            limit=args.limit,
+            force=args.force,
+            apply=args.apply,
+            output_path=args.output,
+            generation_version=args.generation_version,
+            audit_only=args.audit_only,
+        )
+    )
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/migrate_scene_bundles.py
+++ b/backend/scripts/migrate_scene_bundles.py
@@ -1,16 +1,17 @@
 """Migrate legacy characters to versioned Scene Bundles (Issue #272).
 
-Defaults to dry-run. Writes only with explicit --apply after validation.
+Defaults to dry-run. Production writes require --apply-from-report <dryrun.json>
+so the reviewed candidate is written verbatim (no second LLM call).
 
 Examples:
-  # Audit + generate candidates for 12 featured characters (no DB writes)
-  python scripts/migrate_scene_bundles.py --featured
+  # Generate reviewable candidates (no DB writes)
+  python scripts/migrate_scene_bundles.py --featured --output tmp/featured_dryrun.json
 
-  # Specific IDs
-  python scripts/migrate_scene_bundles.py --ids 4,13,67,71,73
+  # After review, write exactly those candidates
+  python scripts/migrate_scene_bundles.py --apply-from-report tmp/featured_dryrun.json --ids 71,73,67
 
-  # After review, apply validated candidates only
-  python scripts/migrate_scene_bundles.py --featured --apply
+  # Audit persona/scenario split only
+  python scripts/migrate_scene_bundles.py --featured --audit-only
 """
 
 from __future__ import annotations
@@ -32,7 +33,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from database import SessionLocal
-from services.scene_bundle_migrator import SceneBundleMigrator, select_characters
+from services.scene_bundle_migrator import (
+    SceneBundleMigrator,
+    load_candidates_from_report,
+    select_characters,
+)
 from utils.character_content_version import SCENE_BUNDLE_GENERATION_VERSION
 
 logger = logging.getLogger(__name__)
@@ -53,12 +58,12 @@ def _parse_args() -> argparse.Namespace:
         "--ids",
         type=str,
         default="",
-        help="Comma-separated character IDs to process.",
+        help="Comma-separated character IDs to process / filter apply-from-report.",
     )
     parser.add_argument(
         "--featured",
         action="store_true",
-        help="Process featured characters only.",
+        help="Process featured characters only (dry-run / audit).",
     )
     parser.add_argument(
         "--limit",
@@ -79,7 +84,14 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--apply",
         action="store_true",
-        help="Write validated candidates to the database. Without this flag, dry-run only.",
+        help="DEPRECATED unsafe mode. Use --apply-from-report instead.",
+    )
+    parser.add_argument(
+        "--apply-from-report",
+        type=str,
+        default="",
+        help="Path to a reviewed dry-run JSON report. Writes those candidates verbatim "
+        "(no LLM regeneration). Refuses if live baseline_fingerprint drifted.",
     )
     parser.add_argument(
         "--output",
@@ -92,6 +104,11 @@ def _parse_args() -> argparse.Namespace:
         type=str,
         default=SCENE_BUNDLE_GENERATION_VERSION,
         help="Target generation_version stamp.",
+    )
+    parser.add_argument(
+        "--skip-english",
+        action="store_true",
+        help="Do not generate EN bundles; clear opening_line_en/default_state_json_en on apply.",
     )
     return parser.parse_args()
 
@@ -114,15 +131,19 @@ def _print_candidate(candidate) -> None:
         logger.info("  errors: %s", "; ".join(candidate.validation_errors))
     audit = candidate.audit or {}
     logger.info(
-        "  audit: dynamics=%s persona_len=%s scene_locks=%s",
+        "  audit: dynamics=%s persona_len=%s→compact=%s locks=%s en_cleared=%s",
         audit.get("has_explicit_dynamics"),
         audit.get("persona_len"),
+        audit.get("compact_persona_len"),
         audit.get("scene_lock_hints"),
+        audit.get("english_fields_cleared"),
     )
     old = candidate.old or {}
     new = candidate.new or {}
     logger.info("  OLD opening: %s", _preview_text(old.get("opening_line")))
     logger.info("  NEW opening: %s", _preview_text(new.get("opening_line")))
+    if new.get("opening_line_en"):
+        logger.info("  NEW opening_en: %s", _preview_text(new.get("opening_line_en")))
     logger.info("  OLD scene_summary: %s", _preview_text(old.get("scene_summary")))
     logger.info("  NEW scene_summary: %s", _preview_text(new.get("scene_summary")))
     logger.info("  NEW scenario_hook: %s", _preview_text(new.get("scenario_hook"), 200))
@@ -131,9 +152,10 @@ def _print_candidate(candidate) -> None:
     logger.info("  OLD 环境: %s", _preview_text(str(old_env or "")))
     logger.info("  NEW 环境: %s", _preview_text(str(new_env or "")))
     logger.info(
-        "  meta: version=%s hash=%s",
+        "  meta: version=%s hash=%s baseline=%s",
         new.get("generation_version"),
         _preview_text(new.get("source_hash"), 16),
+        _preview_text(candidate.baseline_fingerprint, 16),
     )
 
 
@@ -144,12 +166,12 @@ async def run_audit_only(
     limit: int,
     output_path: str,
 ) -> int:
-    """Persona/scenario separation preview without calling the LLM."""
     from services.scene_bundle_migrator import snapshot_character_content
     from utils.persona_scenario_split import migration_audit_flags, separate_persona_and_scenario
     from utils.character_content_version import (
         SCENE_BUNDLE_GENERATION_VERSION,
         character_needs_regeneration,
+        compute_baseline_fingerprint,
         compute_source_hash,
     )
 
@@ -184,6 +206,7 @@ async def run_audit_only(
                 "character_id": character.id,
                 "name": character.name,
                 "needs_regeneration": stale,
+                "baseline_fingerprint": compute_baseline_fingerprint(character),
                 "audit": audit,
                 "old": snapshot_character_content(character),
                 "proposed": {
@@ -193,6 +216,7 @@ async def run_audit_only(
                     "source_hash": compute_source_hash(
                         name=character.name or "",
                         description=character.description or "",
+                        backstory=character.backstory or "",
                         persona_prompt=persona,
                         scenario_hook=hook,
                         voice_style=character.voice_style or "",
@@ -229,6 +253,75 @@ async def run_audit_only(
     return 0
 
 
+async def run_apply_from_report(
+    *,
+    report_path: str,
+    character_ids: Optional[Sequence[int]],
+) -> int:
+    """Write reviewed dry-run candidates verbatim — no LLM calls."""
+    logger.warning(
+        "APPLY-FROM-REPORT — writing reviewed candidates from %s (no LLM regeneration).",
+        report_path,
+    )
+    candidates = load_candidates_from_report(report_path)
+    if character_ids:
+        allow = set(character_ids)
+        candidates = [c for c in candidates if c.character_id in allow]
+
+    session = SessionLocal()
+    applied = refused = skipped = 0
+    # Migrator only needed for apply_candidate helper (no AI).
+    migrator = SceneBundleMigrator(ai_manager=None, force=False)
+    try:
+        from models import Character
+
+        for candidate in candidates:
+            if candidate.skipped:
+                skipped += 1
+                logger.info("[%s] %s SKIP (was idempotent in report)", candidate.character_id, candidate.name)
+                continue
+            if not candidate.validation_ok:
+                refused += 1
+                logger.warning(
+                    "[%s] %s REFUSE — report marked invalid: %s",
+                    candidate.character_id,
+                    candidate.name,
+                    candidate.validation_errors,
+                )
+                continue
+
+            character = (
+                session.query(Character)
+                .filter(Character.id == candidate.character_id)
+                .first()
+            )
+            if not character:
+                refused += 1
+                logger.warning("[%s] REFUSE — character not found", candidate.character_id)
+                continue
+
+            if migrator.apply_candidate(character, candidate, require_baseline_match=True):
+                session.add(character)
+                session.commit()
+                applied += 1
+                logger.info("[%s] %s applied from report", character.id, character.name)
+            else:
+                session.rollback()
+                refused += 1
+    finally:
+        session.close()
+
+    summary = {
+        "mode": "apply-from-report",
+        "report": report_path,
+        "applied": applied,
+        "refused": refused,
+        "skipped_idempotent": skipped,
+    }
+    logger.info("Summary: %s", summary)
+    return 0 if refused == 0 else 2
+
+
 async def run_migration(
     *,
     character_ids: Optional[Sequence[int]],
@@ -236,14 +329,26 @@ async def run_migration(
     limit: int,
     force: bool,
     apply: bool,
+    apply_from_report: str,
     output_path: str,
     generation_version: str,
     audit_only: bool = False,
+    skip_english: bool = False,
 ) -> int:
+    if apply and not apply_from_report:
+        logger.error(
+            "Bare --apply is disabled. Generate a dry-run report, review it, then run:\n"
+            "  python scripts/migrate_scene_bundles.py --apply-from-report <report.json> [--ids ...]"
+        )
+        return 1
+
+    if apply_from_report:
+        return await run_apply_from_report(
+            report_path=apply_from_report,
+            character_ids=character_ids,
+        )
+
     if audit_only:
-        if apply:
-            logger.error("--audit-only cannot be combined with --apply")
-            return 1
         return await run_audit_only(
             character_ids=character_ids,
             featured_only=featured_only,
@@ -251,10 +356,7 @@ async def run_migration(
             output_path=output_path,
         )
 
-    if apply:
-        logger.warning("APPLY MODE — validated candidates will be written to the database.")
-    else:
-        logger.info("DRY-RUN mode — no database writes (pass --apply to write).")
+    logger.info("DRY-RUN mode — no database writes.")
 
     from services.ai_model_manager import AIModelManager
 
@@ -268,11 +370,12 @@ async def run_migration(
         ai_manager=manager,
         generation_version=generation_version,
         force=force,
+        generate_english=not skip_english,
     )
 
     session = SessionLocal()
     report = {
-        "mode": "apply" if apply else "dry-run",
+        "mode": "dry-run",
         "generation_version": generation_version,
         "started_at": datetime.now(timezone.utc).isoformat(),
         "candidates": [],
@@ -292,7 +395,7 @@ async def run_migration(
             return 0
 
         logger.info("Processing %d character(s)...", len(characters))
-        ok = fail = skipped = applied = 0
+        ok = fail = skipped = 0
 
         for character in characters:
             candidate = await migrator.build_candidate(character)
@@ -306,30 +409,24 @@ async def run_migration(
                 fail += 1
                 continue
             ok += 1
-            if apply:
-                if migrator.apply_candidate(character, candidate):
-                    session.add(character)
-                    session.commit()
-                    applied += 1
-                    logger.info("  applied id=%s", character.id)
-                else:
-                    session.rollback()
-                    fail += 1
-                    ok -= 1
 
         report["summary"] = {
             "matched": len(characters),
             "validation_ok": ok,
             "validation_failed": fail,
             "skipped_idempotent": skipped,
-            "applied": applied if apply else 0,
+            "applied": 0,
         }
         logger.info("Summary: %s", report["summary"])
+        logger.info(
+            "Next: review this report, then apply with "
+            "--apply-from-report <this file> [--ids ...]"
+        )
     finally:
         session.close()
 
     out = Path(output_path) if output_path else Path("tmp") / (
-        f"scene_bundle_migration_{'apply' if apply else 'dryrun'}_"
+        f"scene_bundle_migration_dryrun_"
         f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
     )
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -342,8 +439,8 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
     args = _parse_args()
     ids = _parse_ids(args.ids)
-    if not ids and not args.featured and args.limit <= 0:
-        logger.error("Specify --featured, --ids, or --limit to select characters.")
+    if not args.apply_from_report and not ids and not args.featured and args.limit <= 0:
+        logger.error("Specify --featured, --ids, --limit, or --apply-from-report.")
         sys.exit(1)
 
     code = asyncio.run(
@@ -353,9 +450,11 @@ def main() -> None:
             limit=args.limit,
             force=args.force,
             apply=args.apply,
+            apply_from_report=args.apply_from_report,
             output_path=args.output,
             generation_version=args.generation_version,
             audit_only=args.audit_only,
+            skip_english=args.skip_english,
         )
     )
     sys.exit(code)

--- a/backend/scripts/migrate_scene_bundles.py
+++ b/backend/scripts/migrate_scene_bundles.py
@@ -87,6 +87,12 @@ def _parse_args() -> argparse.Namespace:
         help="DEPRECATED unsafe mode. Use --apply-from-report instead.",
     )
     parser.add_argument(
+        "--adopt-existing",
+        action="store_true",
+        help="Dry-run: promote live persona/opening/state into a reviewable report "
+        "(no LLM). Use for hand-edited pilots then --apply-from-report.",
+    )
+    parser.add_argument(
         "--apply-from-report",
         type=str,
         default="",
@@ -322,6 +328,77 @@ async def run_apply_from_report(
     return 0 if refused == 0 else 2
 
 
+async def run_adopt_existing(
+    *,
+    character_ids: Optional[Sequence[int]],
+    featured_only: bool,
+    limit: int,
+    output_path: str,
+    generation_version: str,
+) -> int:
+    """Promote live hand-edited content into an apply-ready dry-run report (no LLM)."""
+    logger.info("ADOPT-EXISTING dry-run — no database writes; no LLM.")
+    migrator = SceneBundleMigrator(
+        ai_manager=None,
+        generation_version=generation_version,
+        force=True,
+        generate_english=False,
+    )
+    session = SessionLocal()
+    report = {
+        "mode": "adopt-existing",
+        "generation_version": generation_version,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "candidates": [],
+        "summary": {},
+    }
+    try:
+        characters = select_characters(
+            session,
+            character_ids=character_ids,
+            featured_only=featured_only,
+            limit=limit,
+        )
+        if not characters:
+            logger.warning("No characters matched selection filters.")
+            report["summary"] = {"matched": 0}
+            return 0
+
+        ok = fail = 0
+        for character in characters:
+            candidate = migrator.build_adopt_existing_candidate(character)
+            _print_candidate(candidate)
+            report["candidates"].append(candidate.to_dict())
+            if candidate.validation_ok:
+                ok += 1
+            else:
+                fail += 1
+
+        report["summary"] = {
+            "matched": len(characters),
+            "validation_ok": ok,
+            "validation_failed": fail,
+            "skipped_idempotent": 0,
+            "applied": 0,
+        }
+        logger.info("Summary: %s", report["summary"])
+        logger.info(
+            "Next: review this report, then apply with "
+            "--apply-from-report <this file> [--ids ...]"
+        )
+    finally:
+        session.close()
+
+    out = Path(output_path) if output_path else Path("tmp") / (
+        f"scene_bundle_adopt_existing_"
+        f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    logger.info("Wrote adopt-existing report: %s", out)
+    return 0 if fail == 0 else 2
+
+
 async def run_migration(
     *,
     character_ids: Optional[Sequence[int]],
@@ -334,6 +411,7 @@ async def run_migration(
     generation_version: str,
     audit_only: bool = False,
     skip_english: bool = False,
+    adopt_existing: bool = False,
 ) -> int:
     if apply and not apply_from_report:
         logger.error(
@@ -346,6 +424,15 @@ async def run_migration(
         return await run_apply_from_report(
             report_path=apply_from_report,
             character_ids=character_ids,
+        )
+
+    if adopt_existing:
+        return await run_adopt_existing(
+            character_ids=character_ids,
+            featured_only=featured_only,
+            limit=limit,
+            output_path=output_path,
+            generation_version=generation_version,
         )
 
     if audit_only:
@@ -455,6 +542,7 @@ def main() -> None:
             generation_version=args.generation_version,
             audit_only=args.audit_only,
             skip_english=args.skip_english,
+            adopt_existing=args.adopt_existing,
         )
     )
     sys.exit(code)

--- a/backend/services/ai_model_manager.py
+++ b/backend/services/ai_model_manager.py
@@ -235,12 +235,15 @@ class AIModelManager:
         character: Character,
         user: Optional[User] = None,
         language: Optional[str] = None,
+        *,
+        allow_split_fallback: bool = True,
     ) -> Dict[str, Any]:
         """
         Atomically generate opening_line + default state for one shared scene.
 
         Falls back to separate opening + state calls if the provider lacks
-        generate_scene_bootstrap or the atomic call fails empty.
+        generate_scene_bootstrap or the atomic call fails empty — unless
+        allow_split_fallback is False (migration / strict atomic mode).
         """
         safe_mode = (character.nsfw_level or 0) == 0
         selected_provider = await self._select_model(user, character)
@@ -284,6 +287,12 @@ class AIModelManager:
                             return bundle
                     except Exception as exc:
                         self.logger.warning("Scene bootstrap fallback failed: %s", exc)
+
+        if not allow_split_fallback:
+            self.logger.warning(
+                "⚠️ Atomic scene bootstrap unavailable; refusing split fallback"
+            )
+            return {}
 
         # Legacy split path — better than nothing, but not atomic
         self.logger.warning("⚠️ Falling back to split opening + state seed generation")

--- a/backend/services/character_service.py
+++ b/backend/services/character_service.py
@@ -467,27 +467,33 @@ class CharacterService:
         character.default_state_json = json.dumps(merged_state, ensure_ascii=False)
         self._last_opening_line_regenerated = True
 
-        scene_summary = (bundle.get("scene_summary") or "").strip() if bundle_ok else ""
-        if scene_summary:
-            character.scene_summary = scene_summary
-            self.logger.info(
-                "Scene bootstrap for %s: %s",
-                character.name,
-                scene_summary[:120],
-            )
+        from utils.character_content_version import (
+            SCENE_BUNDLE_GENERATION_VERSION,
+            clear_generation_metadata,
+            compute_source_hash_for_character,
+        )
+        from utils.persona_scenario_split import derive_scenario_hook
 
-        # Stamp version metadata only when the atomic bundle path succeeded.
         if bundle_ok:
-            from utils.character_content_version import (
-                SCENE_BUNDLE_GENERATION_VERSION,
-                compute_source_hash_for_character,
-            )
-            from utils.persona_scenario_split import derive_scenario_hook
-
+            scene_summary = (bundle.get("scene_summary") or "").strip()
+            if scene_summary:
+                character.scene_summary = scene_summary
+                self.logger.info(
+                    "Scene bootstrap for %s: %s",
+                    character.name,
+                    scene_summary[:120],
+                )
             if not (getattr(character, "scenario_hook", None) or "").strip():
                 character.scenario_hook = derive_scenario_hook(character)
             character.generation_version = SCENE_BUNDLE_GENERATION_VERSION
             character.source_hash = compute_source_hash_for_character(character)
+        else:
+            # Split fallback changed opening/state — never leave stale migration stamps.
+            clear_generation_metadata(character)
+            self.logger.warning(
+                "Cleared generation metadata for %s after non-atomic split fallback",
+                character.name,
+            )
 
     async def _maybe_set_opening_line(self, character: Character, force: bool = False) -> None:
         self._last_opening_line_regenerated = False

--- a/backend/services/character_service.py
+++ b/backend/services/character_service.py
@@ -466,12 +466,28 @@ class CharacterService:
         character.opening_line = opening_line
         character.default_state_json = json.dumps(merged_state, ensure_ascii=False)
         self._last_opening_line_regenerated = True
-        if bundle.get("scene_summary"):
+
+        scene_summary = (bundle.get("scene_summary") or "").strip() if bundle_ok else ""
+        if scene_summary:
+            character.scene_summary = scene_summary
             self.logger.info(
                 "Scene bootstrap for %s: %s",
                 character.name,
-                str(bundle.get("scene_summary"))[:120],
+                scene_summary[:120],
             )
+
+        # Stamp version metadata only when the atomic bundle path succeeded.
+        if bundle_ok:
+            from utils.character_content_version import (
+                SCENE_BUNDLE_GENERATION_VERSION,
+                compute_source_hash_for_character,
+            )
+            from utils.persona_scenario_split import derive_scenario_hook
+
+            if not (getattr(character, "scenario_hook", None) or "").strip():
+                character.scenario_hook = derive_scenario_hook(character)
+            character.generation_version = SCENE_BUNDLE_GENERATION_VERSION
+            character.source_hash = compute_source_hash_for_character(character)
 
     async def _maybe_set_opening_line(self, character: Character, force: bool = False) -> None:
         self._last_opening_line_regenerated = False

--- a/backend/services/character_service.py
+++ b/backend/services/character_service.py
@@ -421,9 +421,11 @@ class CharacterService:
         from prompts.scene_bootstrap import scene_pair_looks_coherent
 
         safe_mode = getattr(character, "nsfw_level", 0) == 0
+        scene_summary_preview = (bundle.get("scene_summary") or "").strip() if bundle else ""
         bundle_ok = bool(
             opening_line
             and state_seed
+            and scene_summary_preview
             and scene_pair_looks_coherent(opening_line, state_seed, safe_mode=safe_mode)
         )
 

--- a/backend/services/gemini_service_new.py
+++ b/backend/services/gemini_service_new.py
@@ -341,6 +341,7 @@ class GeminiService(AIServiceBase):
             or (character.description or "")
             or ""
         )
+        scenario_hook = (getattr(character, "scenario_hook", None) or "").strip()
         prompt_bundle = build_scene_bootstrap_prompt(
             character_name=character.name or "",
             description=character.description or "",
@@ -349,6 +350,7 @@ class GeminiService(AIServiceBase):
             safe_mode=safe_mode,
             state_keys=list(allowed_keys),
             language=target_language,
+            scenario_hook=scenario_hook,
         )
 
         try:
@@ -357,6 +359,7 @@ class GeminiService(AIServiceBase):
                 allowed_keys=allowed_keys,
                 fallback_state=fallback_state,
                 fallback_opening=fallback_opening,
+                safe_mode=safe_mode,
             )
             if result and scene_pair_looks_coherent(
                 result["opening_line"], result["state"], safe_mode=safe_mode
@@ -385,6 +388,7 @@ class GeminiService(AIServiceBase):
                 allowed_keys=allowed_keys,
                 fallback_state=fallback_state,
                 fallback_opening=fallback_opening,
+                safe_mode=safe_mode,
             )
             if result and result.get("opening_line") and result.get("state"):
                 return result
@@ -400,6 +404,7 @@ class GeminiService(AIServiceBase):
         allowed_keys: Iterable[str],
         fallback_state: Dict[str, Any],
         fallback_opening: str,
+        safe_mode: bool = False,
     ) -> Optional[Dict[str, Any]]:
         response = self.client.models.generate_content(
             model=self.model_name,
@@ -421,8 +426,32 @@ class GeminiService(AIServiceBase):
             return None
 
         opening = (parsed.get("opening_line") or "").strip() or fallback_opening
-        state = fallback_state.copy()
-        state.update(parsed.get("state") or {})
+        parsed_state = parsed.get("state") if isinstance(parsed.get("state"), dict) else {}
+        if not parsed_state:
+            self.logger.warning("⚠️ Scene bootstrap returned empty state object")
+            return None
+
+        # Prefer model state. Only fill missing quant keys from soft fallback —
+        # never silently keep generic descriptive env/clothes/posture templates.
+        from prompts.scene_bootstrap import QUANTIFIABLE_KEYS
+
+        state: Dict[str, Any] = {}
+        for key in allowed_keys:
+            key_str = str(key)
+            if key_str in parsed_state:
+                state[key_str] = parsed_state[key_str]
+            elif key_str in QUANTIFIABLE_KEYS and key_str in fallback_state:
+                state[key_str] = fallback_state[key_str]
+
+        required = ("环境", "衣着", "仪态") if safe_mode else ("环境", "衣服", "姿势")
+        for key in required:
+            value = state.get(key)
+            if not isinstance(value, str) or not value.strip():
+                self.logger.warning(
+                    "⚠️ Scene bootstrap missing required descriptive field: %s", key
+                )
+                return None
+
         return {
             "opening_line": opening,
             "state": state,

--- a/backend/services/grok_service.py
+++ b/backend/services/grok_service.py
@@ -225,6 +225,7 @@ class GrokService(AIServiceBase):
             or (character.description or "")
             or ""
         )
+        scenario_hook = (getattr(character, "scenario_hook", None) or "").strip()
         prompt_bundle = build_scene_bootstrap_prompt(
             character_name=character.name or "",
             description=character.description or "",
@@ -233,6 +234,7 @@ class GrokService(AIServiceBase):
             safe_mode=safe_mode,
             state_keys=list(allowed_keys),
             language=target_language,
+            scenario_hook=scenario_hook,
         )
 
         async def _once(user_prompt: str) -> Dict[str, Any]:
@@ -273,7 +275,10 @@ class GrokService(AIServiceBase):
                 "opening_line 必须与这些描述字段处于同一现场。"
             )
             result = await _once(retry_prompt)
-            if result.get("opening_line") and result.get("state"):
+            # Second attempt still requires coherence — never return incoherent partials.
+            if result and scene_pair_looks_coherent(
+                result["opening_line"], result["state"], safe_mode=safe_mode
+            ):
                 return result
         except Exception as exc:
             self.logger.error("❌ Grok scene bootstrap failed: %s", exc)

--- a/backend/services/scene_bundle_migrator.py
+++ b/backend/services/scene_bundle_migrator.py
@@ -314,8 +314,10 @@ class SceneBundleMigrator:
         """
         Write a previously reviewed candidate onto the Character (caller commits).
 
-        When require_baseline_match is True (apply-from-report), refuse if the live
-        character fingerprint no longer matches the dry-run baseline.
+        Never trusts report flags alone:
+        - re-validates opening/state/summary coherence
+        - recomputes source_hash from live generation inputs + reviewed persona/hook
+        - refuses mismatched generation_version / drifted baseline
         """
         if candidate.skipped:
             return False
@@ -345,7 +347,7 @@ class SceneBundleMigrator:
                 )
                 return False
 
-        new = candidate.new
+        new = dict(candidate.new or {})
         required = (
             "persona_prompt",
             "scenario_hook",
@@ -363,6 +365,57 @@ class SceneBundleMigrator:
                     key,
                 )
                 return False
+
+        report_version = str(new.get("generation_version") or "").strip()
+        if report_version != self.generation_version:
+            logger.warning(
+                "Refusing apply for %s: generation_version %r != target %r",
+                candidate.character_id,
+                report_version,
+                self.generation_version,
+            )
+            return False
+
+        safe_mode = int(getattr(character, "nsfw_level", 0) or 0) == 0
+        state = new.get("default_state") if isinstance(new.get("default_state"), dict) else {}
+        recheck = validate_atomic_bundle(
+            opening_line=str(new.get("opening_line") or ""),
+            state=state,
+            scene_summary=str(new.get("scene_summary") or ""),
+            safe_mode=safe_mode,
+            scenario_hook=str(new.get("scenario_hook") or ""),
+        )
+        if recheck:
+            logger.warning(
+                "Refusing apply for %s (%s): report payload failed re-validation: %s",
+                candidate.character_id,
+                candidate.name,
+                recheck,
+            )
+            return False
+
+        expected_hash = compute_source_hash(
+            name=character.name or "",
+            description=character.description or "",
+            backstory=character.backstory or "",
+            persona_prompt=str(new["persona_prompt"]),
+            scenario_hook=str(new["scenario_hook"]),
+            voice_style=character.voice_style or "",
+            nsfw_level=int(character.nsfw_level or 0),
+            generation_version=self.generation_version,
+        )
+        reported_hash = str(new.get("source_hash") or "").strip()
+        if reported_hash and reported_hash != expected_hash:
+            logger.warning(
+                "Refusing apply for %s: report source_hash does not match recomputed hash "
+                "(report may be tampered or stale relative to live inputs)",
+                candidate.character_id,
+            )
+            return False
+
+        # Always persist the recomputed hash / canonical version.
+        new["source_hash"] = expected_hash
+        new["generation_version"] = self.generation_version
 
         character.persona_prompt = new["persona_prompt"]
         character.scenario_hook = new["scenario_hook"]

--- a/backend/services/scene_bundle_migrator.py
+++ b/backend/services/scene_bundle_migrator.py
@@ -439,6 +439,96 @@ class SceneBundleMigrator:
                 )
         return True
 
+    def build_adopt_existing_candidate(self, character: Any) -> SceneBundleCandidate:
+        """
+        Promote live hand-edited content into a reviewable Scene Bundle report row.
+
+        No LLM. Keeps current persona/opening/state; fills scenario_hook + scene_summary
+        when missing so --apply-from-report can stamp generation_version/source_hash.
+        """
+        from utils.persona_scenario_split import derive_scenario_hook
+
+        audit = migration_audit_flags(character)
+        old = snapshot_character_content(character)
+        baseline = compute_baseline_fingerprint(character)
+        candidate = SceneBundleCandidate(
+            character_id=int(character.id),
+            name=str(character.name or ""),
+            audit={**audit, "adopt_existing": True},
+            old=old,
+            baseline_fingerprint=baseline,
+        )
+
+        persona = (
+            (getattr(character, "persona_prompt", None) or "").strip()
+            or (getattr(character, "backstory", None) or "").strip()
+            or (getattr(character, "description", None) or "").strip()
+        )
+        opening = (getattr(character, "opening_line", None) or "").strip()
+        state = _parse_state_json(getattr(character, "default_state_json", None))
+        hook = derive_scenario_hook(character)
+        summary = (getattr(character, "scene_summary", None) or "").strip()
+        if not summary:
+            summary = synthesize_scene_summary(opening, state)
+
+        safe_mode = int(getattr(character, "nsfw_level", 0) or 0) == 0
+        errors = validate_atomic_bundle(
+            opening_line=opening,
+            state=state,
+            scene_summary=summary,
+            safe_mode=safe_mode,
+            scenario_hook=hook,
+        )
+
+        source_hash = compute_source_hash(
+            name=character.name or "",
+            description=character.description or "",
+            backstory=character.backstory or "",
+            persona_prompt=persona,
+            scenario_hook=hook,
+            voice_style=character.voice_style or "",
+            nsfw_level=int(character.nsfw_level or 0),
+            generation_version=self.generation_version,
+        )
+
+        needs_en = bool(
+            (getattr(character, "opening_line_en", None) or "").strip()
+            or (getattr(character, "default_state_json_en", None) or "").strip()
+        )
+        # Hand-edited ZH pilots often keep stale EN that would shadow the new scene.
+        clear_english = bool(needs_en)
+        candidate.new = {
+            "persona_prompt": persona,
+            "scenario_hook": hook,
+            "opening_line": opening or None,
+            "opening_line_en": None if clear_english else getattr(character, "opening_line_en", None),
+            "default_state": state,
+            "default_state_en": {}
+            if clear_english
+            else _parse_state_json(getattr(character, "default_state_json_en", None)),
+            "scene_summary": summary or None,
+            "generation_version": self.generation_version,
+            "source_hash": source_hash,
+            "clear_english_fields": clear_english,
+            "adopt_existing": True,
+        }
+
+        candidate.validation_errors = errors
+        candidate.validation_ok = not errors
+        return candidate
+
+
+def synthesize_scene_summary(opening: str, state: Mapping[str, Any]) -> str:
+    """Build a short scene_summary from live opening + 环境 when column is empty."""
+    env = str((state or {}).get("环境") or "").strip().rstrip("。.")
+    beat = (opening or "").replace("*", " ").replace("\n", " ").strip()
+    beat = " ".join(beat.split())
+    if len(beat) > 72:
+        beat = beat[:69] + "…"
+    if env and beat:
+        return f"{env}。开场：{beat}"[:240]
+    return (env or beat or "当前场景")[:240]
+
 
 def load_candidates_from_report(path: str) -> List[SceneBundleCandidate]:
     with open(path, "r", encoding="utf-8") as fh:
@@ -475,5 +565,6 @@ __all__ = [
     "load_candidates_from_report",
     "select_characters",
     "snapshot_character_content",
+    "synthesize_scene_summary",
     "validate_atomic_bundle",
 ]

--- a/backend/services/scene_bundle_migrator.py
+++ b/backend/services/scene_bundle_migrator.py
@@ -1,0 +1,277 @@
+"""Atomic Scene Bundle migration helpers (Issue #272).
+
+Generates opening_line + default_state_json + scene_summary together from one
+persona_prompt + scenario_hook. Defaults to dry-run; never writes unless apply.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+from prompts.scene_bootstrap import scene_pair_looks_coherent
+from utils.character_content_version import (
+    SCENE_BUNDLE_GENERATION_VERSION,
+    character_needs_regeneration,
+    compute_source_hash,
+)
+from utils.persona_scenario_split import (
+    migration_audit_flags,
+    separate_persona_and_scenario,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SceneBundleCandidate:
+    character_id: int
+    name: str
+    skipped: bool = False
+    skip_reason: str = ""
+    validation_ok: bool = False
+    validation_errors: List[str] = field(default_factory=list)
+    audit: Dict[str, Any] = field(default_factory=dict)
+    old: Dict[str, Any] = field(default_factory=dict)
+    new: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _parse_state_json(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except (TypeError, json.JSONDecodeError):
+        return {}
+
+
+def snapshot_character_content(character: Any) -> Dict[str, Any]:
+    return {
+        "persona_prompt": getattr(character, "persona_prompt", None),
+        "scenario_hook": getattr(character, "scenario_hook", None),
+        "opening_line": getattr(character, "opening_line", None),
+        "default_state": _parse_state_json(getattr(character, "default_state_json", None)),
+        "scene_summary": getattr(character, "scene_summary", None),
+        "generation_version": getattr(character, "generation_version", None),
+        "source_hash": getattr(character, "source_hash", None),
+    }
+
+
+def validate_atomic_bundle(
+    *,
+    opening_line: str,
+    state: Dict[str, Any],
+    scene_summary: str,
+    safe_mode: bool,
+    scenario_hook: str = "",
+) -> List[str]:
+    """Return validation error strings; empty list means OK."""
+    from prompts.scene_bootstrap import GENERIC_FALLBACK_ENV_MARKERS, place_markers
+
+    errors: List[str] = []
+    if not (opening_line or "").strip():
+        errors.append("missing opening_line")
+    if not isinstance(state, dict) or not state:
+        errors.append("missing default_state")
+    if not (scene_summary or "").strip():
+        errors.append("missing scene_summary")
+    if opening_line and state and not scene_pair_looks_coherent(
+        opening_line, state, safe_mode=safe_mode
+    ):
+        errors.append("opening_line/state incoherent")
+
+    env = str((state or {}).get("环境") or "")
+    if any(marker in env for marker in GENERIC_FALLBACK_ENV_MARKERS):
+        errors.append("state uses generic fallback environment")
+
+    hook = (scenario_hook or "").strip()
+    if hook:
+        hook_places = place_markers(hook)
+        scene_places = place_markers(f"{env} {scene_summary}")
+        if hook_places and scene_places.isdisjoint(hook_places):
+            errors.append(
+                f"scenario_hook/environment mismatch (hook={sorted(hook_places)} scene={sorted(scene_places)})"
+            )
+    return errors
+
+
+class SceneBundleMigrator:
+    """Build reviewable Scene Bundle candidates; write only on explicit apply."""
+
+    def __init__(
+        self,
+        *,
+        ai_manager: Any,
+        generation_version: str = SCENE_BUNDLE_GENERATION_VERSION,
+        force: bool = False,
+    ) -> None:
+        self.ai_manager = ai_manager
+        self.generation_version = generation_version
+        self.force = force
+
+    async def build_candidate(self, character: Any) -> SceneBundleCandidate:
+        audit = migration_audit_flags(character)
+        old = snapshot_character_content(character)
+        candidate = SceneBundleCandidate(
+            character_id=int(character.id),
+            name=str(character.name or ""),
+            audit=audit,
+            old=old,
+        )
+
+        new_persona, scenario_hook = separate_persona_and_scenario(character)
+
+        if not self.force and not character_needs_regeneration(
+            character,
+            target_version=self.generation_version,
+            persona_prompt=new_persona,
+            scenario_hook=scenario_hook,
+        ):
+            candidate.skipped = True
+            candidate.skip_reason = "idempotent: generation_version+source_hash match"
+            candidate.validation_ok = True
+            candidate.new = old
+            return candidate
+
+        safe_mode = int(getattr(character, "nsfw_level", 0) or 0) == 0
+
+        # Temporary attributes for AI providers that read character fields.
+        original_persona = getattr(character, "persona_prompt", None)
+        original_hook = getattr(character, "scenario_hook", None)
+        character.persona_prompt = new_persona
+        character.scenario_hook = scenario_hook
+
+        try:
+            bundle = await self.ai_manager.generate_scene_bootstrap(
+                character,
+                allow_split_fallback=False,
+            )
+        except TypeError:
+            # Older managers without allow_split_fallback kwarg.
+            bundle = await self.ai_manager.generate_scene_bootstrap(character)
+        except Exception as exc:
+            character.persona_prompt = original_persona
+            character.scenario_hook = original_hook
+            candidate.validation_errors = [f"scene_bootstrap_failed: {exc}"]
+            candidate.new = {
+                "persona_prompt": new_persona,
+                "scenario_hook": scenario_hook,
+                "opening_line": None,
+                "default_state": {},
+                "scene_summary": None,
+                "generation_version": self.generation_version,
+                "source_hash": None,
+            }
+            return candidate
+        finally:
+            # Restore until apply decides; candidate carries proposed values.
+            character.persona_prompt = original_persona
+            character.scenario_hook = original_hook
+
+        bundle = bundle or {}
+        opening = (bundle.get("opening_line") or "").strip()
+        state = bundle.get("state") if isinstance(bundle.get("state"), dict) else {}
+        summary = (bundle.get("scene_summary") or "").strip()
+
+        # Reject silent split fallback (empty summary + incoherent) for migration.
+        errors = validate_atomic_bundle(
+            opening_line=opening,
+            state=state,
+            scene_summary=summary,
+            safe_mode=safe_mode,
+            scenario_hook=scenario_hook,
+        )
+        # Detect split fallback marker: empty scene_summary after "atomic" path
+        if not summary:
+            errors.append("atomic_bundle_required: scene_summary empty (split fallback?)")
+
+        source_hash = compute_source_hash(
+            name=character.name or "",
+            description=character.description or "",
+            persona_prompt=new_persona,
+            scenario_hook=scenario_hook,
+            voice_style=character.voice_style or "",
+            nsfw_level=int(character.nsfw_level or 0),
+            generation_version=self.generation_version,
+        )
+
+        candidate.new = {
+            "persona_prompt": new_persona,
+            "scenario_hook": scenario_hook,
+            "opening_line": opening or None,
+            "default_state": state,
+            "scene_summary": summary or None,
+            "generation_version": self.generation_version,
+            "source_hash": source_hash,
+        }
+        candidate.validation_errors = errors
+        candidate.validation_ok = not errors
+        return candidate
+
+    def apply_candidate(self, character: Any, candidate: SceneBundleCandidate) -> bool:
+        """
+        Write candidate onto the Character instance (caller commits).
+
+        Returns False if validation failed — never writes partial bundles.
+        """
+        if candidate.skipped:
+            return False
+        if not candidate.validation_ok:
+            logger.warning(
+                "Refusing to apply invalid bundle for %s (%s): %s",
+                candidate.character_id,
+                candidate.name,
+                candidate.validation_errors,
+            )
+            return False
+
+        new = candidate.new
+        character.persona_prompt = new["persona_prompt"]
+        character.scenario_hook = new["scenario_hook"]
+        character.opening_line = new["opening_line"]
+        character.default_state_json = json.dumps(
+            new["default_state"], ensure_ascii=False
+        )
+        character.scene_summary = new["scene_summary"]
+        character.generation_version = new["generation_version"]
+        character.source_hash = new["source_hash"]
+        return True
+
+
+def select_characters(
+    session: Any,
+    *,
+    character_ids: Optional[Sequence[int]] = None,
+    featured_only: bool = False,
+    limit: int = 0,
+) -> List[Any]:
+    from models import Character
+
+    query = session.query(Character).filter(
+        (Character.is_deleted.is_(False)) | (Character.is_deleted.is_(None))
+    )
+    if character_ids:
+        query = query.filter(Character.id.in_(list(character_ids)))
+    if featured_only:
+        query = query.filter(Character.is_featured.is_(True))
+    query = query.order_by(Character.id)
+    if limit and limit > 0:
+        query = query.limit(limit)
+    return list(query.all())
+
+
+__all__ = [
+    "SceneBundleCandidate",
+    "SceneBundleMigrator",
+    "select_characters",
+    "snapshot_character_content",
+    "validate_atomic_bundle",
+]

--- a/backend/services/scene_bundle_migrator.py
+++ b/backend/services/scene_bundle_migrator.py
@@ -1,7 +1,7 @@
 """Atomic Scene Bundle migration helpers (Issue #272).
 
-Generates opening_line + default_state_json + scene_summary together from one
-persona_prompt + scenario_hook. Defaults to dry-run; never writes unless apply.
+Dry-run writes a reviewable JSON report. Apply must load that report and write
+exactly the reviewed candidate — never regenerate via LLM at apply time.
 """
 
 from __future__ import annotations
@@ -9,15 +9,17 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from prompts.scene_bootstrap import scene_pair_looks_coherent
 from utils.character_content_version import (
     SCENE_BUNDLE_GENERATION_VERSION,
     character_needs_regeneration,
+    compute_baseline_fingerprint,
     compute_source_hash,
 )
 from utils.persona_scenario_split import (
+    hook_has_internal_place_conflict,
     migration_audit_flags,
     separate_persona_and_scenario,
 )
@@ -36,9 +38,26 @@ class SceneBundleCandidate:
     audit: Dict[str, Any] = field(default_factory=dict)
     old: Dict[str, Any] = field(default_factory=dict)
     new: Dict[str, Any] = field(default_factory=dict)
+    # Fingerprint of DB content at dry-run time — required for --apply-from-report
+    baseline_fingerprint: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "SceneBundleCandidate":
+        return cls(
+            character_id=int(data["character_id"]),
+            name=str(data.get("name") or ""),
+            skipped=bool(data.get("skipped")),
+            skip_reason=str(data.get("skip_reason") or ""),
+            validation_ok=bool(data.get("validation_ok")),
+            validation_errors=list(data.get("validation_errors") or []),
+            audit=dict(data.get("audit") or {}),
+            old=dict(data.get("old") or {}),
+            new=dict(data.get("new") or {}),
+            baseline_fingerprint=str(data.get("baseline_fingerprint") or ""),
+        )
 
 
 def _parse_state_json(raw: Any) -> Dict[str, Any]:
@@ -56,9 +75,12 @@ def _parse_state_json(raw: Any) -> Dict[str, Any]:
 def snapshot_character_content(character: Any) -> Dict[str, Any]:
     return {
         "persona_prompt": getattr(character, "persona_prompt", None),
+        "backstory": getattr(character, "backstory", None),
         "scenario_hook": getattr(character, "scenario_hook", None),
         "opening_line": getattr(character, "opening_line", None),
+        "opening_line_en": getattr(character, "opening_line_en", None),
         "default_state": _parse_state_json(getattr(character, "default_state_json", None)),
+        "default_state_en": _parse_state_json(getattr(character, "default_state_json_en", None)),
         "scene_summary": getattr(character, "scene_summary", None),
         "generation_version": getattr(character, "generation_version", None),
         "source_hash": getattr(character, "source_hash", None),
@@ -93,6 +115,9 @@ def validate_atomic_bundle(
         errors.append("state uses generic fallback environment")
 
     hook = (scenario_hook or "").strip()
+    if hook and hook_has_internal_place_conflict(hook):
+        errors.append("scenario_hook has internal place conflict")
+
     if hook:
         hook_places = place_markers(hook)
         scene_places = place_markers(f"{env} {scene_summary}")
@@ -104,7 +129,7 @@ def validate_atomic_bundle(
 
 
 class SceneBundleMigrator:
-    """Build reviewable Scene Bundle candidates; write only on explicit apply."""
+    """Build reviewable Scene Bundle candidates; write only reviewed report rows."""
 
     def __init__(
         self,
@@ -112,19 +137,23 @@ class SceneBundleMigrator:
         ai_manager: Any,
         generation_version: str = SCENE_BUNDLE_GENERATION_VERSION,
         force: bool = False,
+        generate_english: bool = True,
     ) -> None:
         self.ai_manager = ai_manager
         self.generation_version = generation_version
         self.force = force
+        self.generate_english = generate_english
 
     async def build_candidate(self, character: Any) -> SceneBundleCandidate:
         audit = migration_audit_flags(character)
         old = snapshot_character_content(character)
+        baseline = compute_baseline_fingerprint(character)
         candidate = SceneBundleCandidate(
             character_id=int(character.id),
             name=str(character.name or ""),
             audit=audit,
             old=old,
+            baseline_fingerprint=baseline,
         )
 
         new_persona, scenario_hook = separate_persona_and_scenario(character)
@@ -142,8 +171,6 @@ class SceneBundleMigrator:
             return candidate
 
         safe_mode = int(getattr(character, "nsfw_level", 0) or 0) == 0
-
-        # Temporary attributes for AI providers that read character fields.
         original_persona = getattr(character, "persona_prompt", None)
         original_hook = getattr(character, "scenario_hook", None)
         character.persona_prompt = new_persona
@@ -152,10 +179,10 @@ class SceneBundleMigrator:
         try:
             bundle = await self.ai_manager.generate_scene_bootstrap(
                 character,
+                language="zh",
                 allow_split_fallback=False,
             )
         except TypeError:
-            # Older managers without allow_split_fallback kwarg.
             bundle = await self.ai_manager.generate_scene_bootstrap(character)
         except Exception as exc:
             character.persona_prompt = original_persona
@@ -165,14 +192,16 @@ class SceneBundleMigrator:
                 "persona_prompt": new_persona,
                 "scenario_hook": scenario_hook,
                 "opening_line": None,
+                "opening_line_en": None,
                 "default_state": {},
+                "default_state_en": {},
                 "scene_summary": None,
                 "generation_version": self.generation_version,
                 "source_hash": None,
+                "clear_english_fields": False,
             }
             return candidate
         finally:
-            # Restore until apply decides; candidate carries proposed values.
             character.persona_prompt = original_persona
             character.scenario_hook = original_hook
 
@@ -181,7 +210,6 @@ class SceneBundleMigrator:
         state = bundle.get("state") if isinstance(bundle.get("state"), dict) else {}
         summary = (bundle.get("scene_summary") or "").strip()
 
-        # Reject silent split fallback (empty summary + incoherent) for migration.
         errors = validate_atomic_bundle(
             opening_line=opening,
             state=state,
@@ -189,13 +217,64 @@ class SceneBundleMigrator:
             safe_mode=safe_mode,
             scenario_hook=scenario_hook,
         )
-        # Detect split fallback marker: empty scene_summary after "atomic" path
         if not summary:
             errors.append("atomic_bundle_required: scene_summary empty (split fallback?)")
+
+        opening_en = None
+        state_en: Dict[str, Any] = {}
+        clear_english = False
+        needs_en = bool(
+            (getattr(character, "opening_line_en", None) or "").strip()
+            or (getattr(character, "default_state_json_en", None) or "").strip()
+        )
+        if self.generate_english and needs_en and not errors:
+            character.persona_prompt = new_persona
+            character.scenario_hook = scenario_hook
+            try:
+                en_bundle = await self.ai_manager.generate_scene_bootstrap(
+                    character,
+                    language="en",
+                    allow_split_fallback=False,
+                )
+            except TypeError:
+                en_bundle = await self.ai_manager.generate_scene_bootstrap(
+                    character, language="en"
+                )
+            except Exception as exc:
+                en_bundle = {}
+                errors.append(f"english_bundle_failed: {exc}")
+            finally:
+                character.persona_prompt = original_persona
+                character.scenario_hook = original_hook
+
+            en_bundle = en_bundle or {}
+            opening_en = (en_bundle.get("opening_line") or "").strip() or None
+            state_en = en_bundle.get("state") if isinstance(en_bundle.get("state"), dict) else {}
+            en_summary = (en_bundle.get("scene_summary") or "").strip()
+            if not opening_en or not state_en:
+                # Do not leave stale English content that would shadow the new ZH bundle.
+                clear_english = True
+                errors.append("english_bundle_incomplete: will clear opening_line_en/default_state_json_en on apply")
+            else:
+                # Soft check — EN state may use Chinese keys still.
+                if not scene_pair_looks_coherent(opening_en, state_en, safe_mode=safe_mode):
+                    clear_english = True
+                    errors.append("english_bundle_incoherent: will clear EN fields on apply")
+                elif not en_summary:
+                    # EN summary optional for chat path; keep opening/state if coherent
+                    pass
+        elif needs_en and not self.generate_english:
+            clear_english = True
+
+        soft_errors = [e for e in errors if e.startswith("english_bundle_")]
+        hard_errors = [e for e in errors if not e.startswith("english_bundle_")]
+        if soft_errors and not hard_errors:
+            clear_english = True
 
         source_hash = compute_source_hash(
             name=character.name or "",
             description=character.description or "",
+            backstory=character.backstory or "",
             persona_prompt=new_persona,
             scenario_hook=scenario_hook,
             voice_style=character.voice_style or "",
@@ -207,20 +286,36 @@ class SceneBundleMigrator:
             "persona_prompt": new_persona,
             "scenario_hook": scenario_hook,
             "opening_line": opening or None,
+            "opening_line_en": None if clear_english else opening_en,
             "default_state": state,
+            "default_state_en": {} if clear_english else state_en,
             "scene_summary": summary or None,
             "generation_version": self.generation_version,
             "source_hash": source_hash,
+            "clear_english_fields": clear_english,
         }
-        candidate.validation_errors = errors
-        candidate.validation_ok = not errors
+        candidate.validation_errors = hard_errors
+        candidate.validation_ok = not hard_errors
+        if clear_english and candidate.validation_ok:
+            candidate.audit = {
+                **candidate.audit,
+                "english_fields_cleared": True,
+                "english_soft_errors": soft_errors,
+            }
         return candidate
 
-    def apply_candidate(self, character: Any, candidate: SceneBundleCandidate) -> bool:
+    def apply_candidate(
+        self,
+        character: Any,
+        candidate: SceneBundleCandidate,
+        *,
+        require_baseline_match: bool = True,
+    ) -> bool:
         """
-        Write candidate onto the Character instance (caller commits).
+        Write a previously reviewed candidate onto the Character (caller commits).
 
-        Returns False if validation failed — never writes partial bundles.
+        When require_baseline_match is True (apply-from-report), refuse if the live
+        character fingerprint no longer matches the dry-run baseline.
         """
         if candidate.skipped:
             return False
@@ -233,7 +328,42 @@ class SceneBundleMigrator:
             )
             return False
 
+        if require_baseline_match:
+            if not candidate.baseline_fingerprint:
+                logger.warning(
+                    "Refusing apply for %s: report missing baseline_fingerprint",
+                    candidate.character_id,
+                )
+                return False
+            live = compute_baseline_fingerprint(character)
+            if live != candidate.baseline_fingerprint:
+                logger.warning(
+                    "Refusing apply for %s (%s): baseline fingerprint mismatch "
+                    "(character changed since dry-run review)",
+                    candidate.character_id,
+                    candidate.name,
+                )
+                return False
+
         new = candidate.new
+        required = (
+            "persona_prompt",
+            "scenario_hook",
+            "opening_line",
+            "default_state",
+            "scene_summary",
+            "generation_version",
+            "source_hash",
+        )
+        for key in required:
+            if key not in new or new[key] in (None, "", {}):
+                logger.warning(
+                    "Refusing apply for %s: incomplete reviewed payload missing %s",
+                    candidate.character_id,
+                    key,
+                )
+                return False
+
         character.persona_prompt = new["persona_prompt"]
         character.scenario_hook = new["scenario_hook"]
         character.opening_line = new["opening_line"]
@@ -243,7 +373,25 @@ class SceneBundleMigrator:
         character.scene_summary = new["scene_summary"]
         character.generation_version = new["generation_version"]
         character.source_hash = new["source_hash"]
+
+        if new.get("clear_english_fields"):
+            character.opening_line_en = None
+            character.default_state_json_en = None
+        else:
+            if new.get("opening_line_en"):
+                character.opening_line_en = new["opening_line_en"]
+            if new.get("default_state_en"):
+                character.default_state_json_en = json.dumps(
+                    new["default_state_en"], ensure_ascii=False
+                )
         return True
+
+
+def load_candidates_from_report(path: str) -> List[SceneBundleCandidate]:
+    with open(path, "r", encoding="utf-8") as fh:
+        report = json.load(fh)
+    rows = report.get("candidates") or []
+    return [SceneBundleCandidate.from_dict(row) for row in rows]
 
 
 def select_characters(
@@ -271,6 +419,7 @@ def select_characters(
 __all__ = [
     "SceneBundleCandidate",
     "SceneBundleMigrator",
+    "load_candidates_from_report",
     "select_characters",
     "snapshot_character_content",
     "validate_atomic_bundle",

--- a/backend/tests/test_scene_bundle_migration.py
+++ b/backend/tests/test_scene_bundle_migration.py
@@ -7,13 +7,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from backend.utils.character_content_version import (
-    SCENE_BUNDLE_GENERATION_VERSION,
-    character_needs_regeneration,
-    clear_generation_metadata,
-    compute_baseline_fingerprint,
-    compute_source_hash,
-)
 from backend.utils.persona_scenario_split import (
     build_compact_persona_prompt,
     build_differentiated_dynamics,
@@ -21,6 +14,13 @@ from backend.utils.persona_scenario_split import (
     extract_and_strip_scene_locks,
     hook_has_internal_place_conflict,
     separate_persona_and_scenario,
+)
+from backend.utils.character_content_version import (
+    SCENE_BUNDLE_GENERATION_VERSION,
+    character_needs_regeneration,
+    clear_generation_metadata,
+    compute_baseline_fingerprint,
+    compute_source_hash,
 )
 from backend.services.scene_bundle_migrator import (
     SceneBundleCandidate,
@@ -332,19 +332,30 @@ async def test_apply_from_report_refuses_baseline_drift():
         source_hash=None,
     )
     baseline = compute_baseline_fingerprint(character)
+    persona = "新persona\n【动力学】\nmask: x"
+    hook = "客厅"
+    expected_hash = compute_source_hash(
+        name="嘉允",
+        description="继母",
+        backstory="",
+        persona_prompt=persona,
+        scenario_hook=hook,
+        voice_style="轻",
+        nsfw_level=1,
+    )
     candidate = SceneBundleCandidate(
         character_id=71,
         name="嘉允",
         validation_ok=True,
         baseline_fingerprint=baseline,
         new={
-            "persona_prompt": "新persona\n【动力学】\nmask: x",
-            "scenario_hook": "客厅",
-            "opening_line": "新开场",
-            "default_state": {"环境": "客厅", "衣服": "家居服", "姿势": "坐着"},
+            "persona_prompt": persona,
+            "scenario_hook": hook,
+            "opening_line": "新开场在客厅",
+            "default_state": {"环境": "家里客厅暖灯", "衣服": "家居服", "姿势": "坐着"},
             "scene_summary": "客厅见面",
             "generation_version": SCENE_BUNDLE_GENERATION_VERSION,
-            "source_hash": "abc123",
+            "source_hash": expected_hash,
             "clear_english_fields": False,
         },
     )
@@ -356,7 +367,163 @@ async def test_apply_from_report_refuses_baseline_drift():
     character.opening_line = "回来了"
     assert compute_baseline_fingerprint(character) == baseline
     assert migrator.apply_candidate(character, candidate, require_baseline_match=True) is True
-    assert character.opening_line == "新开场"
+    assert character.opening_line == "新开场在客厅"
+
+
+def test_apply_refuses_tampered_incoherent_report():
+    character = SimpleNamespace(
+        id=99,
+        name="测试",
+        description="d",
+        backstory="b",
+        persona_prompt="p",
+        voice_style="v",
+        nsfw_level=1,
+        scenario_hook=None,
+        opening_line="旧",
+        opening_line_en=None,
+        default_state_json='{"环境":"旧"}',
+        default_state_json_en=None,
+        scene_summary=None,
+        generation_version=None,
+        source_hash=None,
+    )
+    baseline = compute_baseline_fingerprint(character)
+    candidate = SceneBundleCandidate(
+        character_id=99,
+        name="测试",
+        validation_ok=True,  # report claims OK
+        baseline_fingerprint=baseline,
+        new={
+            "persona_prompt": "恶意",
+            "scenario_hook": "桃花岛",
+            "opening_line": "桃花岛阳光正好，我们去寻宝吧",
+            "default_state": {"环境": "阴暗地牢镣铐叮当", "衣服": "囚衣", "姿势": "反绑"},
+            "scene_summary": "地牢里",
+            "generation_version": SCENE_BUNDLE_GENERATION_VERSION,
+            "source_hash": "deadbeef",
+            "clear_english_fields": False,
+        },
+    )
+    migrator = SceneBundleMigrator(ai_manager=None)
+    assert migrator.apply_candidate(character, candidate, require_baseline_match=True) is False
+    assert character.opening_line == "旧"
+
+
+def test_apply_refuses_fake_version_and_wrong_hash():
+    character = SimpleNamespace(
+        id=1,
+        name="嘉允",
+        description="继母",
+        backstory="",
+        persona_prompt="你是嘉允",
+        voice_style="轻",
+        nsfw_level=1,
+        opening_line="旧",
+        opening_line_en=None,
+        default_state_json='{"环境":"客厅"}',
+        default_state_json_en=None,
+        scene_summary=None,
+        scenario_hook=None,
+        generation_version=None,
+        source_hash=None,
+    )
+    baseline = compute_baseline_fingerprint(character)
+    coherent = {
+        "persona_prompt": "你是嘉允\n【动力学】\nmask: a",
+        "scenario_hook": "客厅",
+        "opening_line": "客厅见",
+        "default_state": {"环境": "家里客厅", "衣服": "家居服", "姿势": "坐着"},
+        "scene_summary": "客厅",
+        "generation_version": "fake_version",
+        "source_hash": "deadbeef",
+        "clear_english_fields": False,
+    }
+    candidate = SceneBundleCandidate(
+        character_id=1,
+        name="嘉允",
+        validation_ok=True,
+        baseline_fingerprint=baseline,
+        new=coherent,
+    )
+    migrator = SceneBundleMigrator(ai_manager=None)
+    assert migrator.apply_candidate(character, candidate) is False
+
+
+def test_baseline_fingerprint_includes_generation_inputs():
+    character = SimpleNamespace(
+        id=1,
+        name="A",
+        description="D1",
+        voice_style="V1",
+        nsfw_level=0,
+        persona_prompt="p",
+        backstory="b",
+        scenario_hook=None,
+        opening_line="o",
+        opening_line_en=None,
+        default_state_json="{}",
+        default_state_json_en=None,
+        scene_summary=None,
+        generation_version=None,
+        source_hash=None,
+    )
+    fp1 = compute_baseline_fingerprint(character)
+    character.name = "B"
+    assert compute_baseline_fingerprint(character) != fp1
+    character.name = "A"
+    character.description = "D2"
+    assert compute_baseline_fingerprint(character) != fp1
+    character.description = "D1"
+    character.voice_style = "V2"
+    assert compute_baseline_fingerprint(character) != fp1
+    character.voice_style = "V1"
+    character.nsfw_level = 3
+    assert compute_baseline_fingerprint(character) != fp1
+
+
+def test_bloated_persona_is_compacted_not_grown():
+    bloated = (
+        "你将扮演叶萱。" + ("详细设定。" * 80)
+        + "\n性格：娇羞多变。\n渴望攻略与吃肉。\n修仙洞府里等待。\n"
+    )
+    character = SimpleNamespace(
+        name="叶萱",
+        description="快穿攻略女主，外表娇羞",
+        voice_style="柔媚",
+        persona_prompt=bloated,
+        backstory=bloated,
+        scenario_hook=None,
+        opening_line="洞府见",
+        default_state_json=json.dumps({"环境": "修仙洞府内"}, ensure_ascii=False),
+    )
+    new_persona, _hook = separate_persona_and_scenario(character)
+    assert len(new_persona) < len(bloated)
+    assert len(new_persona) < 1200
+    assert "【动力学】" in new_persona
+    assert "【扮演】" in new_persona or "【身份核】" in new_persona
+
+
+def test_dynamics_not_shared_skeleton_across_legacies():
+    a = SimpleNamespace(
+        name="叶萱",
+        description="快穿攻略女主，娇羞多变，渴望吃肉",
+        voice_style="柔媚",
+        persona_prompt="叶萱表面娇羞，内心渴望攻略与征服，会主动试探。",
+        backstory="",
+    )
+    b = SimpleNamespace(
+        name="黄蓉",
+        description="机智女侠，丐帮帮主",
+        voice_style="酷女侠",
+        persona_prompt="黄蓉机智聪慧，面对敌人冷静果敢，用谋略引导对方。",
+        backstory="",
+    )
+    da = build_differentiated_dynamics(a, a.persona_prompt)
+    db = build_differentiated_dynamics(b, b.persona_prompt)
+    # Not the same mechanism with only a name splice
+    assert da["initiative"] != db["initiative"] or da["drive"] != db["drive"]
+    assert da["mask"] != db["mask"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scene_bundle_migration.py
+++ b/backend/tests/test_scene_bundle_migration.py
@@ -10,21 +10,47 @@ import pytest
 from backend.utils.character_content_version import (
     SCENE_BUNDLE_GENERATION_VERSION,
     character_needs_regeneration,
+    clear_generation_metadata,
+    compute_baseline_fingerprint,
     compute_source_hash,
 )
 from backend.utils.persona_scenario_split import (
     build_compact_persona_prompt,
+    build_differentiated_dynamics,
     derive_scenario_hook,
-    ensure_dynamics_block,
+    extract_and_strip_scene_locks,
+    hook_has_internal_place_conflict,
     separate_persona_and_scenario,
 )
-from backend.services.scene_bundle_migrator import SceneBundleMigrator, validate_atomic_bundle
+from backend.services.scene_bundle_migrator import (
+    SceneBundleCandidate,
+    SceneBundleMigrator,
+    validate_atomic_bundle,
+)
+from backend.prompts.persona_dynamics import parse_dynamics_from_persona
+
+
+def test_source_hash_includes_backstory_fallback():
+    base = dict(
+        name="角色",
+        persona_prompt="",
+        backstory="完整背景故事",
+        scenario_hook="客厅",
+        voice_style="轻",
+        nsfw_level=1,
+        description="简介",
+    )
+    h1 = compute_source_hash(**base)
+    changed = dict(base)
+    changed["backstory"] = "改过的背景"
+    assert compute_source_hash(**changed) != h1
 
 
 def test_source_hash_stable_and_sensitive():
     base = dict(
         name="嘉允",
         persona_prompt="你是嘉允\n【动力学】\nmask: a",
+        backstory="",
         scenario_hook="家里客厅暖灯",
         voice_style="轻柔",
         nsfw_level=1,
@@ -50,6 +76,7 @@ def test_needs_regeneration_when_missing_version():
         scenario_hook="客厅",
         name="x",
         description="",
+        backstory="",
         persona_prompt="p",
         voice_style="",
         nsfw_level=0,
@@ -63,6 +90,7 @@ def test_needs_regeneration_false_when_current():
     character = SimpleNamespace(
         name="嘉允",
         description="继母",
+        backstory="",
         persona_prompt=persona,
         scenario_hook=hook,
         voice_style="轻",
@@ -74,6 +102,7 @@ def test_needs_regeneration_false_when_current():
         source_hash=compute_source_hash(
             name="嘉允",
             description="继母",
+            backstory="",
             persona_prompt=persona,
             scenario_hook=hook,
             voice_style="轻",
@@ -83,10 +112,22 @@ def test_needs_regeneration_false_when_current():
     assert character_needs_regeneration(character) is False
 
 
-def test_derive_scenario_hook_from_environment():
+def test_clear_generation_metadata():
+    character = SimpleNamespace(
+        generation_version="scene_bundle_v2",
+        source_hash="abc",
+        scene_summary="s",
+    )
+    clear_generation_metadata(character)
+    assert character.generation_version is None
+    assert character.source_hash is None
+    assert character.scene_summary is None
+
+
+def test_derive_scenario_hook_rejects_conflicting_opening():
     character = SimpleNamespace(
         scenario_hook=None,
-        opening_line="你回来了啊",
+        opening_line="夜店吧台边嗨起来",
         default_state_json=json.dumps({"环境": "家里客厅，暖灯"}, ensure_ascii=False),
         persona_prompt="你是嘉允",
         backstory="",
@@ -95,27 +136,52 @@ def test_derive_scenario_hook_from_environment():
     )
     hook = derive_scenario_hook(character)
     assert "客厅" in hook
-    assert "开场" in hook
+    assert "夜店" not in hook
+    assert not hook_has_internal_place_conflict(hook)
 
 
-def test_ensure_dynamics_idempotent_for_existing_block():
-    body = "你是娜琏\n\n【动力学】\nmask: 玩笑\ndrive: 掌控"
-    assert ensure_dynamics_block(body) == body
-
-
-def test_compact_persona_adds_dynamics_when_missing():
-    character = SimpleNamespace(
-        persona_prompt="你是郑恩爱，姨妈。【冲突 Desire vs Role】想被靠近。",
-        backstory="",
-        description="",
-        scenario_hook=None,
-        opening_line=None,
-        default_state_json=None,
-        name="恩爱",
+def test_huangrong_scene_locks_extracted_from_core():
+    persona = (
+        "你将扮演黄蓉。\n"
+        "角色背景\n"
+        "\t•\t身份：丐帮帮主。\n"
+        "\t•\t处境：为探查蒙古军情深入边境，意外被俘，受化功散与春药控制，多次被凌辱。\n"
+        "核心特质\n"
+        "智慧与谋略：你是女诸葛。\n"
     )
-    persona, hook = separate_persona_and_scenario(character)
-    assert "【动力学】" in persona
-    assert hook
+    character = SimpleNamespace(
+        persona_prompt=persona,
+        backstory=persona,
+        description="黄蓉",
+        name="黄蓉",
+        voice_style="酷女侠",
+        scenario_hook=None,
+        opening_line="营帐里风冷",
+        default_state_json=json.dumps({"环境": "简陋边境营帐内"}, ensure_ascii=False),
+    )
+    compact, extracted = extract_and_strip_scene_locks(persona)
+    assert "被俘" in extracted or "春药" in extracted or "化功散" in extracted
+    assert "女诸葛" in compact
+    # Core should shrink vs original after lock extraction
+    new_persona, hook = separate_persona_and_scenario(character)
+    assert "【动力学】" in new_persona
+    assert "被俘" not in new_persona or "场景提示" in new_persona
+    # Lock lines / crisis props moved out of core
+    assert "多次被凌辱" not in new_persona
+    assert "春药" not in new_persona
+    assert "营帐" in hook or extracted
+    dyn = parse_dynamics_from_persona(new_persona)
+    # Must not misclassify 黄蓉 as nightclub dynamics
+    assert "夜店" not in dyn.get("mask", "") and "浪女" not in dyn.get("mask", "")
+
+
+def test_differentiated_dynamics_not_identical_for_two_legacies():
+    a = SimpleNamespace(name="叶萱", description="快穿攻略女主，娇羞多变", voice_style="柔媚")
+    b = SimpleNamespace(name="黄蓉", description="机智女侠，丐帮帮主", voice_style="酷女侠")
+    da = build_differentiated_dynamics(a, "叶萱快穿世界")
+    db = build_differentiated_dynamics(b, "黄蓉武侠机智")
+    assert da != db
+    assert da["mask"] != db["mask"]
 
 
 def test_validate_atomic_bundle_requires_all_three():
@@ -159,7 +225,7 @@ def test_validate_rejects_generic_fallback_environment():
 @pytest.mark.asyncio
 async def test_migrator_refuses_apply_on_validation_failure():
     class StubAI:
-        async def generate_scene_bootstrap(self, character, allow_split_fallback=False):
+        async def generate_scene_bootstrap(self, character, language="zh", allow_split_fallback=False):
             return {
                 "opening_line": "hi",
                 "state": {"环境": "地牢", "衣服": "囚衣", "姿势": "绑着"},
@@ -175,9 +241,11 @@ async def test_migrator_refuses_apply_on_validation_failure():
         voice_style="平静",
         nsfw_level=1,
         opening_line="旧开场",
+        opening_line_en=None,
         default_state_json=json.dumps(
             {"环境": "客厅", "衣服": "家居服", "姿势": "坐着"}, ensure_ascii=False
         ),
+        default_state_json_en=None,
         scene_summary=None,
         scenario_hook=None,
         generation_version=None,
@@ -194,7 +262,7 @@ async def test_migrator_refuses_apply_on_validation_failure():
 @pytest.mark.asyncio
 async def test_migrator_apply_writes_only_when_valid():
     class StubAI:
-        async def generate_scene_bootstrap(self, character, allow_split_fallback=False):
+        async def generate_scene_bootstrap(self, character, language="zh", allow_split_fallback=False):
             return {
                 "opening_line": "新开场，厨房见。",
                 "state": {
@@ -223,21 +291,72 @@ async def test_migrator_apply_writes_only_when_valid():
         voice_style="轻软",
         nsfw_level=1,
         opening_line="旧",
+        opening_line_en="Old English opening that must be cleared or replaced",
         default_state_json='{"环境":"厨房"}',
+        default_state_json_en='{"环境":"old en"}',
         scene_summary=None,
         scenario_hook=None,
         generation_version=None,
         source_hash=None,
     )
-    migrator = SceneBundleMigrator(ai_manager=StubAI(), force=True)
+    migrator = SceneBundleMigrator(ai_manager=StubAI(), force=True, generate_english=True)
     candidate = await migrator.build_candidate(character)
     assert candidate.validation_ok is True
-    assert migrator.apply_candidate(character, candidate) is True
+    assert candidate.baseline_fingerprint
+    # EN stub returns ZH-shaped coherent bundle → may keep or clear; apply must succeed
+    assert migrator.apply_candidate(character, candidate, require_baseline_match=True) is True
     assert character.opening_line.startswith("新开场")
     assert character.generation_version == SCENE_BUNDLE_GENERATION_VERSION
     assert character.source_hash
     assert character.scene_summary
     assert character.scenario_hook
+
+
+@pytest.mark.asyncio
+async def test_apply_from_report_refuses_baseline_drift():
+    character = SimpleNamespace(
+        id=71,
+        name="嘉允",
+        description="继母",
+        persona_prompt="你是嘉允",
+        backstory="",
+        voice_style="轻",
+        nsfw_level=1,
+        opening_line="回来了",
+        opening_line_en=None,
+        default_state_json='{"环境":"客厅"}',
+        default_state_json_en=None,
+        scene_summary=None,
+        scenario_hook=None,
+        generation_version=None,
+        source_hash=None,
+    )
+    baseline = compute_baseline_fingerprint(character)
+    candidate = SceneBundleCandidate(
+        character_id=71,
+        name="嘉允",
+        validation_ok=True,
+        baseline_fingerprint=baseline,
+        new={
+            "persona_prompt": "新persona\n【动力学】\nmask: x",
+            "scenario_hook": "客厅",
+            "opening_line": "新开场",
+            "default_state": {"环境": "客厅", "衣服": "家居服", "姿势": "坐着"},
+            "scene_summary": "客厅见面",
+            "generation_version": SCENE_BUNDLE_GENERATION_VERSION,
+            "source_hash": "abc123",
+            "clear_english_fields": False,
+        },
+    )
+    migrator = SceneBundleMigrator(ai_manager=None)
+    # Drift: change live content after report
+    character.opening_line = "被人改过了"
+    assert migrator.apply_candidate(character, candidate, require_baseline_match=True) is False
+    # Restore and apply
+    character.opening_line = "回来了"
+    assert compute_baseline_fingerprint(character) == baseline
+    assert migrator.apply_candidate(character, candidate, require_baseline_match=True) is True
+    assert character.opening_line == "新开场"
 
 
 @pytest.mark.asyncio
@@ -248,6 +367,7 @@ async def test_migrator_idempotent_skip():
             backstory="",
             description="",
             name="嘉允",
+            voice_style="轻",
             scenario_hook=None,
             opening_line=None,
             default_state_json=None,
@@ -257,6 +377,7 @@ async def test_migrator_idempotent_skip():
     source_hash = compute_source_hash(
         name="嘉允",
         description="继母",
+        backstory="",
         persona_prompt=persona,
         scenario_hook=hook,
         voice_style="轻",
@@ -276,7 +397,9 @@ async def test_migrator_idempotent_skip():
         voice_style="轻",
         nsfw_level=1,
         opening_line="回来了",
+        opening_line_en=None,
         default_state_json=json.dumps({"环境": "家里客厅"}, ensure_ascii=False),
+        default_state_json_en=None,
         scene_summary="客厅",
         scenario_hook=hook,
         generation_version=SCENE_BUNDLE_GENERATION_VERSION,
@@ -286,3 +409,12 @@ async def test_migrator_idempotent_skip():
     candidate = await migrator.build_candidate(character)
     assert candidate.skipped is True
     assert candidate.validation_ok is True
+
+
+def test_ensure_dynamics_idempotent_for_existing_block():
+    body = "你是娜琏\n\n【动力学】\nmask: 玩笑\ndrive: 掌控"
+    character = SimpleNamespace(name="娜琏", description="夜店", voice_style="沙哑")
+    from backend.utils.persona_scenario_split import ensure_dynamics_block
+
+    assert ensure_dynamics_block(character, body) == body
+    assert parse_dynamics_from_persona(body)["mask"] == "玩笑"

--- a/backend/tests/test_scene_bundle_migration.py
+++ b/backend/tests/test_scene_bundle_migration.py
@@ -1,0 +1,288 @@
+"""Tests for Issue #272 Scene Bundle versioning + migration helpers."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from backend.utils.character_content_version import (
+    SCENE_BUNDLE_GENERATION_VERSION,
+    character_needs_regeneration,
+    compute_source_hash,
+)
+from backend.utils.persona_scenario_split import (
+    build_compact_persona_prompt,
+    derive_scenario_hook,
+    ensure_dynamics_block,
+    separate_persona_and_scenario,
+)
+from backend.services.scene_bundle_migrator import SceneBundleMigrator, validate_atomic_bundle
+
+
+def test_source_hash_stable_and_sensitive():
+    base = dict(
+        name="嘉允",
+        persona_prompt="你是嘉允\n【动力学】\nmask: a",
+        scenario_hook="家里客厅暖灯",
+        voice_style="轻柔",
+        nsfw_level=1,
+        description="继母",
+    )
+    h1 = compute_source_hash(**base)
+    h2 = compute_source_hash(**base)
+    assert h1 == h2
+    assert len(h1) == 64
+
+    changed = dict(base)
+    changed["scenario_hook"] = "夜店吧台"
+    assert compute_source_hash(**changed) != h1
+
+
+def test_needs_regeneration_when_missing_version():
+    character = SimpleNamespace(
+        generation_version=None,
+        source_hash=None,
+        opening_line="hi",
+        default_state_json="{}",
+        scene_summary="s",
+        scenario_hook="客厅",
+        name="x",
+        description="",
+        persona_prompt="p",
+        voice_style="",
+        nsfw_level=0,
+    )
+    assert character_needs_regeneration(character) is True
+
+
+def test_needs_regeneration_false_when_current():
+    persona = "你是嘉允\n【动力学】\nmask: 关心"
+    hook = "家里客厅"
+    character = SimpleNamespace(
+        name="嘉允",
+        description="继母",
+        persona_prompt=persona,
+        scenario_hook=hook,
+        voice_style="轻",
+        nsfw_level=1,
+        opening_line="回来了",
+        default_state_json='{"环境":"客厅"}',
+        scene_summary="客厅见面",
+        generation_version=SCENE_BUNDLE_GENERATION_VERSION,
+        source_hash=compute_source_hash(
+            name="嘉允",
+            description="继母",
+            persona_prompt=persona,
+            scenario_hook=hook,
+            voice_style="轻",
+            nsfw_level=1,
+        ),
+    )
+    assert character_needs_regeneration(character) is False
+
+
+def test_derive_scenario_hook_from_environment():
+    character = SimpleNamespace(
+        scenario_hook=None,
+        opening_line="你回来了啊",
+        default_state_json=json.dumps({"环境": "家里客厅，暖灯"}, ensure_ascii=False),
+        persona_prompt="你是嘉允",
+        backstory="",
+        description="",
+        name="嘉允",
+    )
+    hook = derive_scenario_hook(character)
+    assert "客厅" in hook
+    assert "开场" in hook
+
+
+def test_ensure_dynamics_idempotent_for_existing_block():
+    body = "你是娜琏\n\n【动力学】\nmask: 玩笑\ndrive: 掌控"
+    assert ensure_dynamics_block(body) == body
+
+
+def test_compact_persona_adds_dynamics_when_missing():
+    character = SimpleNamespace(
+        persona_prompt="你是郑恩爱，姨妈。【冲突 Desire vs Role】想被靠近。",
+        backstory="",
+        description="",
+        scenario_hook=None,
+        opening_line=None,
+        default_state_json=None,
+        name="恩爱",
+    )
+    persona, hook = separate_persona_and_scenario(character)
+    assert "【动力学】" in persona
+    assert hook
+
+
+def test_validate_atomic_bundle_requires_all_three():
+    state = {"环境": "明亮的厨房", "衣服": "围裙", "姿势": "站着洗碗"}
+    assert (
+        validate_atomic_bundle(
+            opening_line="回来了？",
+            state=state,
+            scene_summary="厨房晚饭后",
+            safe_mode=False,
+            scenario_hook="明亮的厨房，水槽旁",
+        )
+        == []
+    )
+    errs = validate_atomic_bundle(
+        opening_line="回来了？",
+        state=state,
+        scene_summary="",
+        safe_mode=False,
+    )
+    assert any("scene_summary" in e for e in errs)
+
+
+def test_validate_rejects_generic_fallback_environment():
+    state = {
+        "环境": "私密空间光线暖柔，空气中弥漫甜香",
+        "衣服": "贴身衣物",
+        "姿势": "站着",
+    }
+    errs = validate_atomic_bundle(
+        opening_line="厨房见",
+        state=state,
+        scene_summary="暧昧的私密空间",
+        safe_mode=False,
+        scenario_hook="明亮的厨房",
+    )
+    assert any("fallback" in e for e in errs)
+    assert any("mismatch" in e for e in errs)
+
+
+@pytest.mark.asyncio
+async def test_migrator_refuses_apply_on_validation_failure():
+    class StubAI:
+        async def generate_scene_bootstrap(self, character, allow_split_fallback=False):
+            return {
+                "opening_line": "hi",
+                "state": {"环境": "地牢", "衣服": "囚衣", "姿势": "绑着"},
+                "scene_summary": "",
+            }
+
+    character = SimpleNamespace(
+        id=1,
+        name="测试",
+        description="d",
+        persona_prompt="你是测试",
+        backstory="",
+        voice_style="平静",
+        nsfw_level=1,
+        opening_line="旧开场",
+        default_state_json=json.dumps(
+            {"环境": "客厅", "衣服": "家居服", "姿势": "坐着"}, ensure_ascii=False
+        ),
+        scene_summary=None,
+        scenario_hook=None,
+        generation_version=None,
+        source_hash=None,
+        is_deleted=False,
+    )
+    migrator = SceneBundleMigrator(ai_manager=StubAI(), force=True)
+    candidate = await migrator.build_candidate(character)
+    assert candidate.validation_ok is False
+    assert migrator.apply_candidate(character, candidate) is False
+    assert character.opening_line == "旧开场"
+
+
+@pytest.mark.asyncio
+async def test_migrator_apply_writes_only_when_valid():
+    class StubAI:
+        async def generate_scene_bootstrap(self, character, allow_split_fallback=False):
+            return {
+                "opening_line": "新开场，厨房见。",
+                "state": {
+                    "环境": "明亮厨房",
+                    "衣服": "围裙家居服",
+                    "姿势": "站在水槽前",
+                    "胸部": "被围裙盖住",
+                    "下体": "平静",
+                    "情绪": {"value": 5, "description": "温和"},
+                    "好感度": {"value": 5, "description": "亲近"},
+                    "信任度": {"value": 5, "description": "信任"},
+                    "兴奋度": {"value": 2, "description": "低"},
+                    "疲惫度": {"value": 3, "description": "轻"},
+                    "欲望值": {"value": 2, "description": "低"},
+                    "敏感度": {"value": 3, "description": "中"},
+                },
+                "scene_summary": "晚饭后的厨房，姨妈擦着手看向门口",
+            }
+
+    character = SimpleNamespace(
+        id=67,
+        name="恩爱",
+        description="姨妈",
+        persona_prompt="你是郑恩爱。【冲突 Desire vs Role】",
+        backstory="你是郑恩爱。【冲突 Desire vs Role】",
+        voice_style="轻软",
+        nsfw_level=1,
+        opening_line="旧",
+        default_state_json='{"环境":"厨房"}',
+        scene_summary=None,
+        scenario_hook=None,
+        generation_version=None,
+        source_hash=None,
+    )
+    migrator = SceneBundleMigrator(ai_manager=StubAI(), force=True)
+    candidate = await migrator.build_candidate(character)
+    assert candidate.validation_ok is True
+    assert migrator.apply_candidate(character, candidate) is True
+    assert character.opening_line.startswith("新开场")
+    assert character.generation_version == SCENE_BUNDLE_GENERATION_VERSION
+    assert character.source_hash
+    assert character.scene_summary
+    assert character.scenario_hook
+
+
+@pytest.mark.asyncio
+async def test_migrator_idempotent_skip():
+    persona = build_compact_persona_prompt(
+        SimpleNamespace(
+            persona_prompt="你是嘉允\n【动力学】\nmask: 关心\ndrive: 靠近",
+            backstory="",
+            description="",
+            name="嘉允",
+            scenario_hook=None,
+            opening_line=None,
+            default_state_json=None,
+        )
+    )
+    hook = "家里客厅｜开场：回来了"
+    source_hash = compute_source_hash(
+        name="嘉允",
+        description="继母",
+        persona_prompt=persona,
+        scenario_hook=hook,
+        voice_style="轻",
+        nsfw_level=1,
+    )
+
+    class BoomAI:
+        async def generate_scene_bootstrap(self, *args, **kwargs):
+            raise AssertionError("should not call AI on idempotent skip")
+
+    character = SimpleNamespace(
+        id=71,
+        name="嘉允",
+        description="继母",
+        persona_prompt=persona,
+        backstory="",
+        voice_style="轻",
+        nsfw_level=1,
+        opening_line="回来了",
+        default_state_json=json.dumps({"环境": "家里客厅"}, ensure_ascii=False),
+        scene_summary="客厅",
+        scenario_hook=hook,
+        generation_version=SCENE_BUNDLE_GENERATION_VERSION,
+        source_hash=source_hash,
+    )
+    migrator = SceneBundleMigrator(ai_manager=BoomAI(), force=False)
+    candidate = await migrator.build_candidate(character)
+    assert candidate.skipped is True
+    assert candidate.validation_ok is True

--- a/backend/tests/test_scene_bundle_migration.py
+++ b/backend/tests/test_scene_bundle_migration.py
@@ -585,3 +585,61 @@ def test_ensure_dynamics_idempotent_for_existing_block():
 
     assert ensure_dynamics_block(character, body) == body
     assert parse_dynamics_from_persona(body)["mask"] == "玩笑"
+
+
+def test_adopt_existing_fills_summary_and_validates():
+    from backend.services.scene_bundle_migrator import synthesize_scene_summary
+
+    persona = (
+        "你是金硕宇\n\n【开场场景】傍晚影音室，落地灯与暂停的游戏。\n"
+        "【关系】对用户心动。\n【动力学】\nmask: 装没事\ndrive: 想她坐旁边\n"
+        "defense: a\ninitiative: b\npressure_shift: c\nboundary: d"
+    )
+    opening = (
+        "*影音室只亮着一盏落地灯，电视定格在游戏过场*"
+        "……你回来了。要不要坐下？地上也行。"
+    )
+    state = {
+        "环境": "傍晚影音室：落地灯、半拉窗帘、电视暂停画面",
+        "衣服": "帽衫",
+        "姿势": "坐在地毯上",
+        "胸部": "平静",
+        "下体": "自然",
+        "情绪": {"value": 6, "description": "忐忑"},
+        "好感度": {"value": 6, "description": "心动"},
+        "信任度": {"value": 5, "description": "愿意"},
+        "兴奋度": {"value": 3, "description": "低"},
+        "疲惫度": {"value": 2, "description": "不累"},
+        "欲望值": {"value": 3, "description": "想陪伴"},
+        "敏感度": {"value": 5, "description": "易红"},
+    }
+    summary = synthesize_scene_summary(opening, state)
+    assert "影音室" in summary
+    assert "开场" in summary
+
+    character = SimpleNamespace(
+        id=70,
+        name="金硕宇",
+        description="富二代",
+        persona_prompt=persona,
+        backstory=persona,
+        voice_style="低",
+        nsfw_level=1,
+        opening_line=opening,
+        opening_line_en=None,
+        default_state_json=json.dumps(state, ensure_ascii=False),
+        default_state_json_en=None,
+        scene_summary=None,
+        scenario_hook=None,
+        generation_version=None,
+        source_hash=None,
+    )
+    migrator = SceneBundleMigrator(ai_manager=None, force=True, generate_english=False)
+    candidate = migrator.build_adopt_existing_candidate(character)
+    assert candidate.validation_ok, candidate.validation_errors
+    assert candidate.new["scene_summary"]
+    assert candidate.new["scenario_hook"]
+    assert candidate.new["generation_version"] == SCENE_BUNDLE_GENERATION_VERSION
+    assert candidate.new.get("adopt_existing") is True
+    assert candidate.baseline_fingerprint
+    assert len(candidate.new["source_hash"]) == 64

--- a/backend/utils/character_content_version.py
+++ b/backend/utils/character_content_version.py
@@ -1,0 +1,146 @@
+"""Character content generation version + source-hash helpers (Issue #272)."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Mapping, Optional
+
+# Bump when Scene Bundle prompt contract or hash inputs change.
+SCENE_BUNDLE_GENERATION_VERSION = "scene_bundle_v1"
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_for_hash(value: Any) -> str:
+    """Collapse whitespace so trivial edits do not thrash hashes."""
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return _WHITESPACE_RE.sub(" ", text)
+
+
+def compute_source_hash(
+    *,
+    name: str,
+    persona_prompt: str,
+    scenario_hook: str,
+    voice_style: str = "",
+    nsfw_level: int = 0,
+    description: str = "",
+    generation_version: str = SCENE_BUNDLE_GENERATION_VERSION,
+) -> str:
+    """
+    Hash of inputs that must stay coherent with a Scene Bundle.
+
+    Changing any of these means opening_line / default_state / scene_summary
+    should be regenerated together.
+    """
+    payload = "\n".join(
+        [
+            f"generation_version={normalize_for_hash(generation_version)}",
+            f"name={normalize_for_hash(name)}",
+            f"description={normalize_for_hash(description)}",
+            f"persona_prompt={normalize_for_hash(persona_prompt)}",
+            f"scenario_hook={normalize_for_hash(scenario_hook)}",
+            f"voice_style={normalize_for_hash(voice_style)}",
+            f"nsfw_level={int(nsfw_level or 0)}",
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def compute_source_hash_for_character(
+    character: Any,
+    *,
+    persona_prompt: Optional[str] = None,
+    scenario_hook: Optional[str] = None,
+    generation_version: str = SCENE_BUNDLE_GENERATION_VERSION,
+) -> str:
+    """Compute hash from a Character ORM row (or duck-typed object)."""
+    return compute_source_hash(
+        name=getattr(character, "name", "") or "",
+        description=getattr(character, "description", "") or "",
+        persona_prompt=(
+            persona_prompt
+            if persona_prompt is not None
+            else (getattr(character, "persona_prompt", None) or "")
+        ),
+        scenario_hook=(
+            scenario_hook
+            if scenario_hook is not None
+            else (getattr(character, "scenario_hook", None) or "")
+        ),
+        voice_style=getattr(character, "voice_style", "") or "",
+        nsfw_level=int(getattr(character, "nsfw_level", 0) or 0),
+        generation_version=generation_version,
+    )
+
+
+def character_needs_regeneration(
+    character: Any,
+    *,
+    target_version: str = SCENE_BUNDLE_GENERATION_VERSION,
+    persona_prompt: Optional[str] = None,
+    scenario_hook: Optional[str] = None,
+) -> bool:
+    """
+    True when the character has no migration marker, wrong version,
+    missing scene fields, or stale source_hash.
+    """
+    current_version = (getattr(character, "generation_version", None) or "").strip()
+    if current_version != target_version:
+        return True
+
+    current_hash = (getattr(character, "source_hash", None) or "").strip()
+    if not current_hash:
+        return True
+
+    expected = compute_source_hash_for_character(
+        character,
+        persona_prompt=persona_prompt,
+        scenario_hook=scenario_hook,
+        generation_version=target_version,
+    )
+    if current_hash != expected:
+        return True
+
+    if not (getattr(character, "opening_line", None) or "").strip():
+        return True
+    if not (getattr(character, "default_state_json", None) or "").strip():
+        return True
+    if not (getattr(character, "scene_summary", None) or "").strip():
+        return True
+    hook = (
+        scenario_hook
+        if scenario_hook is not None
+        else (getattr(character, "scenario_hook", None) or "")
+    )
+    if not str(hook).strip():
+        return True
+    return False
+
+
+def bundle_metadata_dict(
+    *,
+    generation_version: str,
+    source_hash: str,
+    scene_summary: str,
+    scenario_hook: str,
+) -> Mapping[str, str]:
+    return {
+        "generation_version": generation_version,
+        "source_hash": source_hash,
+        "scene_summary": scene_summary,
+        "scenario_hook": scenario_hook,
+    }
+
+
+__all__ = [
+    "SCENE_BUNDLE_GENERATION_VERSION",
+    "bundle_metadata_dict",
+    "character_needs_regeneration",
+    "compute_source_hash",
+    "compute_source_hash_for_character",
+    "normalize_for_hash",
+]

--- a/backend/utils/character_content_version.py
+++ b/backend/utils/character_content_version.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, Mapping, Optional
 
 # Bump when Scene Bundle prompt contract or hash inputs change.
-SCENE_BUNDLE_GENERATION_VERSION = "scene_bundle_v2"
+SCENE_BUNDLE_GENERATION_VERSION = "scene_bundle_v3"
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
@@ -103,8 +103,11 @@ def compute_source_hash_for_character(
 
 def compute_baseline_fingerprint(character: Any) -> str:
     """
-    Fingerprint of currently stored content used to detect drift between
-    dry-run review and later --apply-from-report.
+    Fingerprint of currently stored generation inputs + outputs used to detect
+    drift between dry-run review and later --apply-from-report.
+
+    Must include every field that affects Scene Bundle generation inputs
+    (name/description/voice/nsfw) as well as stored content fields.
     """
     state_raw = getattr(character, "default_state_json", None) or ""
     if isinstance(state_raw, dict):
@@ -112,6 +115,10 @@ def compute_baseline_fingerprint(character: Any) -> str:
     payload = "\n".join(
         [
             f"id={getattr(character, 'id', '')}",
+            f"name={normalize_for_hash(getattr(character, 'name', None))}",
+            f"description={normalize_for_hash(getattr(character, 'description', None))}",
+            f"voice_style={normalize_for_hash(getattr(character, 'voice_style', None))}",
+            f"nsfw_level={int(getattr(character, 'nsfw_level', 0) or 0)}",
             f"persona={normalize_for_hash(getattr(character, 'persona_prompt', None))}",
             f"backstory={normalize_for_hash(getattr(character, 'backstory', None))}",
             f"hook={normalize_for_hash(getattr(character, 'scenario_hook', None))}",

--- a/backend/utils/character_content_version.py
+++ b/backend/utils/character_content_version.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from typing import Any, Mapping, Optional
 
 # Bump when Scene Bundle prompt contract or hash inputs change.
-SCENE_BUNDLE_GENERATION_VERSION = "scene_bundle_v1"
+SCENE_BUNDLE_GENERATION_VERSION = "scene_bundle_v2"
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
@@ -20,6 +21,24 @@ def normalize_for_hash(value: Any) -> str:
     return _WHITESPACE_RE.sub(" ", text)
 
 
+def effective_persona_text(character: Any, *, persona_prompt: Optional[str] = None) -> str:
+    """
+    Same fallback chain generators use: persona_prompt → backstory → description.
+    Hash must include this effective text, not only the persona_prompt column.
+    """
+    if persona_prompt is not None:
+        text = (persona_prompt or "").strip()
+        if text:
+            return text
+    stored = (getattr(character, "persona_prompt", None) or "").strip()
+    if stored:
+        return stored
+    backstory = (getattr(character, "backstory", None) or "").strip()
+    if backstory:
+        return backstory
+    return (getattr(character, "description", None) or "").strip()
+
+
 def compute_source_hash(
     *,
     name: str,
@@ -28,20 +47,23 @@ def compute_source_hash(
     voice_style: str = "",
     nsfw_level: int = 0,
     description: str = "",
+    backstory: str = "",
     generation_version: str = SCENE_BUNDLE_GENERATION_VERSION,
 ) -> str:
     """
     Hash of inputs that must stay coherent with a Scene Bundle.
 
-    Changing any of these means opening_line / default_state / scene_summary
-    should be regenerated together.
+    Includes backstory because generators fall back to it when persona_prompt
+    is empty. Changing any of these means opening/state/summary must regenerate.
     """
+    effective = (persona_prompt or "").strip() or (backstory or "").strip() or (description or "").strip()
     payload = "\n".join(
         [
             f"generation_version={normalize_for_hash(generation_version)}",
             f"name={normalize_for_hash(name)}",
             f"description={normalize_for_hash(description)}",
-            f"persona_prompt={normalize_for_hash(persona_prompt)}",
+            f"backstory={normalize_for_hash(backstory)}",
+            f"effective_persona={normalize_for_hash(effective)}",
             f"scenario_hook={normalize_for_hash(scenario_hook)}",
             f"voice_style={normalize_for_hash(voice_style)}",
             f"nsfw_level={int(nsfw_level or 0)}",
@@ -58,14 +80,16 @@ def compute_source_hash_for_character(
     generation_version: str = SCENE_BUNDLE_GENERATION_VERSION,
 ) -> str:
     """Compute hash from a Character ORM row (or duck-typed object)."""
+    resolved_persona = (
+        persona_prompt
+        if persona_prompt is not None
+        else (getattr(character, "persona_prompt", None) or "")
+    )
     return compute_source_hash(
         name=getattr(character, "name", "") or "",
         description=getattr(character, "description", "") or "",
-        persona_prompt=(
-            persona_prompt
-            if persona_prompt is not None
-            else (getattr(character, "persona_prompt", None) or "")
-        ),
+        backstory=getattr(character, "backstory", "") or "",
+        persona_prompt=resolved_persona or "",
         scenario_hook=(
             scenario_hook
             if scenario_hook is not None
@@ -75,6 +99,39 @@ def compute_source_hash_for_character(
         nsfw_level=int(getattr(character, "nsfw_level", 0) or 0),
         generation_version=generation_version,
     )
+
+
+def compute_baseline_fingerprint(character: Any) -> str:
+    """
+    Fingerprint of currently stored content used to detect drift between
+    dry-run review and later --apply-from-report.
+    """
+    state_raw = getattr(character, "default_state_json", None) or ""
+    if isinstance(state_raw, dict):
+        state_raw = json.dumps(state_raw, ensure_ascii=False, sort_keys=True)
+    payload = "\n".join(
+        [
+            f"id={getattr(character, 'id', '')}",
+            f"persona={normalize_for_hash(getattr(character, 'persona_prompt', None))}",
+            f"backstory={normalize_for_hash(getattr(character, 'backstory', None))}",
+            f"hook={normalize_for_hash(getattr(character, 'scenario_hook', None))}",
+            f"opening={normalize_for_hash(getattr(character, 'opening_line', None))}",
+            f"opening_en={normalize_for_hash(getattr(character, 'opening_line_en', None))}",
+            f"state={normalize_for_hash(state_raw)}",
+            f"state_en={normalize_for_hash(getattr(character, 'default_state_json_en', None))}",
+            f"summary={normalize_for_hash(getattr(character, 'scene_summary', None))}",
+            f"version={normalize_for_hash(getattr(character, 'generation_version', None))}",
+            f"source_hash={normalize_for_hash(getattr(character, 'source_hash', None))}",
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def clear_generation_metadata(character: Any) -> None:
+    """Invalidate migration stamps so non-atomic writes cannot look migrated."""
+    character.generation_version = None
+    character.source_hash = None
+    character.scene_summary = None
 
 
 def character_needs_regeneration(
@@ -140,7 +197,10 @@ __all__ = [
     "SCENE_BUNDLE_GENERATION_VERSION",
     "bundle_metadata_dict",
     "character_needs_regeneration",
+    "clear_generation_metadata",
+    "compute_baseline_fingerprint",
     "compute_source_hash",
     "compute_source_hash_for_character",
+    "effective_persona_text",
     "normalize_for_hash",
 ]

--- a/backend/utils/character_utils.py
+++ b/backend/utils/character_utils.py
@@ -109,6 +109,14 @@ def transform_character_to_response(character: Character, db_session=None) -> Di
                 response["defaultState"] = parsed
         except Exception:
             pass
+    if getattr(character, "scene_summary", None):
+        response["sceneSummary"] = character.scene_summary
+    if getattr(character, "scenario_hook", None):
+        response["scenarioHook"] = character.scenario_hook
+    if getattr(character, "generation_version", None):
+        response["generationVersion"] = character.generation_version
+    if getattr(character, "source_hash", None):
+        response["sourceHash"] = character.source_hash
 
     # Include multilingual fields for localization (English)
     if getattr(character, "name_en", None):

--- a/backend/utils/persona_scenario_split.py
+++ b/backend/utils/persona_scenario_split.py
@@ -7,10 +7,12 @@ import re
 from typing import Any, Dict, Mapping, Optional, Tuple
 
 from prompts.persona_dynamics import (
+    DYNAMICS_KEYS,
     format_dynamics_block,
+    normalize_dynamics,
     parse_dynamics_from_persona,
-    resolve_dynamics,
 )
+from prompts.scene_bootstrap import place_markers
 
 # Sections that often lock a replaceable scene into the persona core.
 _SCENE_SECTION_RE = re.compile(
@@ -18,7 +20,11 @@ _SCENE_SECTION_RE = re.compile(
     r"(?=^\s*(?:[-*•]?\s*)?(?:核心|性格|行为|外貌|关系|冲突|口吻|扮演|动力学|【)|\Z)"
 )
 
-# Phrases that permanently bake a concrete location into the core.
+# Bullet/line items that permanently bake a concrete crisis scene into the core.
+_SCENE_LOCK_LINE_RE = re.compile(
+    r"(?m)^\s*(?:[-*•]\s*)?(?:处境|当前场景|开场场景)\s*[:：].+$"
+)
+
 _SCENE_LOCK_HINTS = (
     "地牢",
     "牢房",
@@ -30,6 +36,12 @@ _SCENE_LOCK_HINTS = (
     "客厅沙发",
     "夜店吧台",
     "修仙洞府",
+    "多次被凌辱",
+    "受化功散",
+)
+
+_STRUCTURED_SECTION_RE = re.compile(
+    r"(?ms)^【(?P<title>关系|冲突(?: Desire vs Role)?|冲突（轻）|性格锚|口吻|外形要点|扮演)】\s*(?P<body>.*?)(?=^【|\Z)"
 )
 
 
@@ -55,12 +67,97 @@ def _parse_state(character: Any) -> Dict[str, Any]:
         return {}
 
 
+def strip_scene_sections(persona_text: str) -> str:
+    """Remove dedicated 处境/场景 sections that belong in scenario_hook."""
+    text = persona_text or ""
+    cleaned = _SCENE_SECTION_RE.sub("", text)
+    cleaned = _SCENE_LOCK_LINE_RE.sub("", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned
+
+
+def extract_and_strip_scene_locks(persona_text: str) -> Tuple[str, str]:
+    """
+    Pull replaceable crisis/scene prose out of the persona core.
+
+    Returns (compact_persona, extracted_scene_bits).
+    """
+    text = persona_text or ""
+    extracted: list[str] = []
+
+    # Capture dedicated scene sections / lines before stripping.
+    for m in _SCENE_SECTION_RE.finditer(text):
+        bit = re.sub(r"\s+", " ", m.group(0)).strip()
+        if bit:
+            extracted.append(bit[:240])
+    for m in _SCENE_LOCK_LINE_RE.finditer(text):
+        bit = m.group(0).strip().lstrip("-*• \t")
+        if bit:
+            extracted.append(bit[:240])
+
+    text = strip_scene_sections(text)
+
+    # Bullet/lines that still mention lock hints
+    kept_lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if any(h in stripped for h in _SCENE_LOCK_HINTS) and (
+            stripped.startswith(("•", "-", "*", "处境", "当前"))
+            or "处境" in stripped[:12]
+            or re.match(r"^[-*•]?\s*处境", stripped)
+        ):
+            extracted.append(stripped.lstrip("-*• \t").strip()[:240])
+            continue
+        kept_lines.append(line)
+    text = "\n".join(kept_lines)
+
+    # Line-level: pull crisis props out of personality lists without nuking the whole persona.
+    hard_crisis = ("被俘", "春药", "化功散", "多次被凌辱", "地牢", "牢房", "受化功散")
+    kept_lines2: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and any(h in stripped for h in hard_crisis):
+            extracted.append(stripped[:240])
+            continue
+        kept_lines2.append(line)
+    text = "\n".join(kept_lines2)
+
+    # Paragraph-level only when multiple lock hints cluster in a long block.
+    paragraphs = re.split(r"\n\s*\n", text)
+    kept_paras: list[str] = []
+    for para in paragraphs:
+        hits = sum(1 for h in _SCENE_LOCK_HINTS if h in para)
+        if hits >= 3 and len(para) > 120:
+            extracted.append(re.sub(r"\s+", " ", para).strip()[:240])
+            continue
+        if para.strip():
+            kept_paras.append(para)
+    compact = "\n\n".join(p.strip() for p in kept_paras if p.strip()).strip()
+    # If we over-stripped into emptiness, fall back to section-stripped source minus hard lines only.
+    if not compact:
+        fallback_lines = []
+        for line in strip_scene_sections(persona_text or "").splitlines():
+            if any(h in line for h in hard_crisis):
+                continue
+            fallback_lines.append(line)
+        compact = "\n".join(fallback_lines).strip()
+    # Dedupe while preserving order
+    seen = set()
+    unique_bits: list[str] = []
+    for bit in extracted:
+        if bit not in seen:
+            seen.add(bit)
+            unique_bits.append(bit)
+    scene_bits = "；".join(unique_bits)
+    return compact, scene_bits
+
+
 def derive_scenario_hook(character: Any) -> str:
     """
     Build a short replaceable current-scene hook.
 
-    Prefer persisted scenario_hook; else environment + opening beat.
-    Never invent bondage/dungeon unless already present in current content.
+    Prefer persisted scenario_hook; else environment alone.
+    Only append opening when it does not conflict with environment place markers.
     """
     existing = (getattr(character, "scenario_hook", None) or "").strip()
     if existing:
@@ -69,18 +166,27 @@ def derive_scenario_hook(character: Any) -> str:
     state = _parse_state(character)
     env = str(state.get("环境") or "").strip()
     opening = (getattr(character, "opening_line", None) or "").strip()
-
-    if env and opening:
-        # Keep hook short: environment + one beat cue from opening.
-        beat = opening.replace("\n", " ")
-        if len(beat) > 80:
-            beat = beat[:77] + "…"
-        return f"{env}｜开场：{beat}"[:240]
+    persona = _persona_source(character)
+    _, extracted = extract_and_strip_scene_locks(persona)
 
     if env:
+        env_places = place_markers(env)
+        opening_places = place_markers(opening)
+        if opening and env_places and opening_places and env_places.isdisjoint(opening_places):
+            # Conflicting worlds — keep environment only; do not bake two plays into hook.
+            return env[:240]
+        if opening and not (env_places and opening_places and env_places.isdisjoint(opening_places)):
+            beat = opening.replace("\n", " ")
+            if len(beat) > 80:
+                beat = beat[:77] + "…"
+            # Prefer env as canonical place; opening only as beat cue when places agree/empty.
+            if not env_places or not opening_places or not env_places.isdisjoint(opening_places):
+                return f"{env}｜开场：{beat}"[:240]
         return env[:240]
 
-    persona = _persona_source(character)
+    if extracted:
+        return extracted[:240]
+
     m = re.search(
         r"(?ms)^\s*(?:[-*•]?\s*)?(?:处境|当前场景|开场场景)\s*[:：]\s*(.+?)(?=^\s*\S|\Z)",
         persona,
@@ -95,21 +201,93 @@ def derive_scenario_hook(character: Any) -> str:
     return f"与{name}的初次见面现场"
 
 
-def strip_scene_sections(persona_text: str) -> str:
-    """Remove dedicated 处境/场景 sections that belong in scenario_hook."""
-    text = persona_text or ""
-    cleaned = _SCENE_SECTION_RE.sub("", text)
-    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
-    return cleaned
+def _structured_bits(persona_text: str) -> Dict[str, str]:
+    bits: Dict[str, str] = {}
+    for m in _STRUCTURED_SECTION_RE.finditer(persona_text or ""):
+        title = m.group("title")
+        body = (m.group("body") or "").strip()
+        if title.startswith("冲突"):
+            bits["冲突"] = body
+        else:
+            bits[title] = body
+    return bits
 
 
-def ensure_dynamics_block(persona_text: str) -> str:
-    """Append a short 【动力学】 card when missing."""
+def build_differentiated_dynamics(character: Any, persona_text: str) -> Dict[str, str]:
+    """
+    Build a short Dynamics card that is character-specific.
+
+    Prefer explicit 【动力学】; else derive from structured slim sections and
+    distinctive persona fragments — never return the same generic else-template
+    for every legacy character.
+    """
+    parsed = parse_dynamics_from_persona(persona_text)
+    if any(parsed.values()):
+        return parsed
+
+    bits = _structured_bits(persona_text)
+    name = (getattr(character, "name", None) or "她").strip()
+    # Prefer the short public name without series suffix.
+    short_name = re.split(r"\s+|《", name, maxsplit=1)[0] or "她"
+    description = (getattr(character, "description", None) or "").strip()
+    voice = (getattr(character, "voice_style", None) or "").strip()
+
+    conflict = bits.get("冲突", "")
+    relation = bits.get("关系", "")
+    anchor = bits.get("性格锚", "")
+    tone = bits.get("口吻", "") or voice
+
+    out: Dict[str, str] = {k: "" for k in DYNAMICS_KEYS}
+
+    if conflict or "Desire vs Role" in (persona_text or "") or "【冲突" in (persona_text or ""):
+        out["mask"] = f"先维持{short_name}在关系里得体的一面" + (
+            f"：{(relation[:40] if relation else '可靠、照顾人的日常角色')}"
+        )
+        out["drive"] = (
+            conflict.split("。")[0].strip()[:80]
+            if conflict
+            else "想被靠近与确认，却不能丢掉自己的体面"
+        )
+        out["defense"] = "被点破时用身份口吻/推开半寸/改话题护住自己"
+        out["initiative"] = "真要越线时先犹豫半拍，再用动作而不是演讲推进"
+        out["pressure_shift"] = "压力升高时嘴上还想维持原来的自己，身体先诚实"
+        out["boundary"] = f"不会立刻变成无脑献上的服务机；仍是{short_name}"
+    elif any(k in (persona_text or "") for k in ("夜店", "吧台", "酒吧")):
+        out["mask"] = f"用大胆玩笑盖住认真动情——像{short_name}本人，不是通用浪女模板"
+        out["drive"] = (anchor.split("。")[0].strip()[:80] if anchor else "要掌控节奏、被接住、玩得过瘾")
+        out["defense"] = "被看穿时更用力挑衅或把人往暗处带"
+        out["initiative"] = "先撩并留半拍门槛，被接住才加码"
+        out["pressure_shift"] = "真动情时玩笑变少，动作和眼神比嘴更直"
+        out["boundary"] = "不做谁都行的换皮服务机"
+    else:
+        # Fingerprint from description/persona so two legacy blobs don't share one card.
+        seed = (description or persona_text or short_name)[:120]
+        trait = ""
+        for token in ("机智", "温柔", "霸道", "娇羞", "冷淡", "腹黑", "母性", "傲娇", "顺从", "挑逗"):
+            if token in seed:
+                trait = token
+                break
+        trait = trait or "她惯有的语气"
+        out["mask"] = f"用{trait}保护自己，先像{short_name}再进亲密"
+        if description:
+            out["drive"] = f"想被认真对待：{description[:60]}"
+        else:
+            out["drive"] = f"想被当成{short_name}本人，而不是工具"
+        out["defense"] = f"被逼近时先缩回自己的说话方式" + (f"（{tone[:24]}）" if tone else "")
+        out["initiative"] = f"主动时用符合{short_name}口吻的一小步"
+        out["pressure_shift"] = "压力升高时破绽从语气和动作里漏出来"
+        out["boundary"] = f"不忽然换成另一个人的性格；始终是{short_name}"
+
+    return normalize_dynamics(out)
+
+
+def ensure_dynamics_block(character: Any, persona_text: str) -> str:
+    """Append a differentiated 【动力学】 card when missing."""
     body = (persona_text or "").strip()
     parsed = parse_dynamics_from_persona(body)
     if any(parsed.values()):
         return body
-    dynamics = resolve_dynamics(body)
+    dynamics = build_differentiated_dynamics(character, body)
     block = format_dynamics_block(dynamics)
     if not block:
         return body
@@ -122,29 +300,32 @@ def build_compact_persona_prompt(character: Any) -> str:
     """
     Stable character core + short Dynamics.
 
-    Does not invent a new identity. Keeps structured slim personas (嘉允/娜琏/恩爱)
-    largely intact; strips dedicated scene sections from bloated legacy prompts.
+    Strips replaceable scene locks out of the core; keeps slim structured
+    personas (嘉允/娜琏/恩爱) largely intact.
     """
-    existing_hook_aware = _persona_source(character)
-    core = strip_scene_sections(existing_hook_aware)
+    source = _persona_source(character)
+    core, _extracted = extract_and_strip_scene_locks(source)
 
-    # Soft cue: remind generators that clothes/place live in current state.
-    if core and "当前状态" not in core and "以【当前状态】为准" not in core:
-        # Only append for long legacy blobs that hard-code wardrobe/place.
-        if len(core) > 900 or any(h in core for h in _SCENE_LOCK_HINTS):
+    if core and "以【当前状态】为准" not in core and "当前状态" not in core:
+        if len(source) > 900 or _extracted or any(h in source for h in _SCENE_LOCK_HINTS):
             core = (
                 f"{core.rstrip()}\n\n"
                 "【场景提示】具体衣服/姿势/环境以【当前状态】与 scenario_hook 为准；"
                 "不要把可替换的地牢/厨房/客厅等开场现场永久写进角色核。"
             )
 
-    return ensure_dynamics_block(core)
+    return ensure_dynamics_block(character, core)
 
 
 def separate_persona_and_scenario(character: Any) -> Tuple[str, str]:
     """Return (persona_prompt, scenario_hook) for migration candidates."""
     persona = build_compact_persona_prompt(character)
     hook = derive_scenario_hook(character)
+    # If hook is still empty-ish but we extracted scene locks, prefer those.
+    if not hook or hook.startswith("与"):
+        _, extracted = extract_and_strip_scene_locks(_persona_source(character))
+        if extracted:
+            hook = extracted[:240]
     return persona, hook
 
 
@@ -152,11 +333,25 @@ def persona_has_explicit_dynamics(persona_text: str) -> bool:
     return any(parse_dynamics_from_persona(persona_text or "").values())
 
 
+def hook_has_internal_place_conflict(hook: str) -> bool:
+    """True when a single hook string contains disjoint place worlds joined by ｜."""
+    text = hook or ""
+    if "｜" not in text and "|" not in text:
+        return False
+    parts = re.split(r"[｜|]", text)
+    if len(parts) < 2:
+        return False
+    left = place_markers(parts[0])
+    right = place_markers(parts[1])
+    return bool(left and right and left.isdisjoint(right))
+
+
 def migration_audit_flags(character: Any) -> Dict[str, Any]:
     """Read-only signals for dry-run reports."""
     persona = _persona_source(character)
     state = _parse_state(character)
     env = str(state.get("环境") or "")
+    compact, extracted = extract_and_strip_scene_locks(persona)
     return {
         "has_explicit_dynamics": persona_has_explicit_dynamics(persona),
         "persona_duplicates_backstory": (
@@ -166,19 +361,26 @@ def migration_audit_flags(character: Any) -> Dict[str, Any]:
             == (getattr(character, "backstory") or "").strip()
         ),
         "persona_len": len(persona),
+        "compact_persona_len": len(compact),
+        "extracted_scene_bits": extracted[:160],
         "environment": env[:120],
         "scene_lock_hints": [h for h in _SCENE_LOCK_HINTS if h in persona],
         "generation_version": getattr(character, "generation_version", None),
         "source_hash": getattr(character, "source_hash", None),
         "has_scene_summary": bool((getattr(character, "scene_summary", None) or "").strip()),
         "has_scenario_hook": bool((getattr(character, "scenario_hook", None) or "").strip()),
+        "has_opening_line_en": bool((getattr(character, "opening_line_en", None) or "").strip()),
+        "has_default_state_en": bool((getattr(character, "default_state_json_en", None) or "").strip()),
     }
 
 
 __all__ = [
     "build_compact_persona_prompt",
+    "build_differentiated_dynamics",
     "derive_scenario_hook",
     "ensure_dynamics_block",
+    "extract_and_strip_scene_locks",
+    "hook_has_internal_place_conflict",
     "migration_audit_flags",
     "persona_has_explicit_dynamics",
     "separate_persona_and_scenario",

--- a/backend/utils/persona_scenario_split.py
+++ b/backend/utils/persona_scenario_split.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from prompts.persona_dynamics import (
     DYNAMICS_KEYS,
@@ -213,24 +213,134 @@ def _structured_bits(persona_text: str) -> Dict[str, str]:
     return bits
 
 
+def _short_name(character: Any) -> str:
+    name = (getattr(character, "name", None) or "她").strip()
+    return re.split(r"\s+|《", name, maxsplit=1)[0] or "她"
+
+
+def _is_already_slim(persona_text: str) -> bool:
+    """Structured short personas (嘉允/娜琏/恩爱 style) should stay intact."""
+    text = persona_text or ""
+    if len(text) > 900:
+        return False
+    return any(
+        marker in text
+        for marker in ("【关系】", "【冲突", "【性格锚】", "【动力学】", "【口吻】")
+    )
+
+
+def _clause_around(text: str, needle: str, radius: int = 36) -> str:
+    body = text or ""
+    idx = body.find(needle)
+    if idx < 0:
+        return ""
+    # Expand to nearest sentence / section boundaries.
+    start = idx
+    while start > 0 and body[start - 1] not in "。！？\n【】":
+        start -= 1
+        if idx - start > radius + 20:
+            break
+    end = idx + len(needle)
+    while end < len(body) and body[end] not in "。！？\n【":
+        end += 1
+        if end - idx > radius + 40:
+            break
+    snippet = body[start:end]
+    # Drop section headers accidentally captured.
+    snippet = re.sub(r"【[^】]*】?", "", snippet)
+    snippet = re.sub(r"^[^【\n]{0,8}】", "", snippet)
+    snippet = re.sub(r"\s+", " ", snippet).strip(" ；;,.。：:")
+    if len(snippet) < 4:
+        return ""
+    return snippet[:80]
+
+
+def _first_matching_clause(text: str, needles: Sequence[str]) -> str:
+    for needle in needles:
+        if not needle:
+            continue
+        hit = _clause_around(text, needle)
+        if hit and "【" not in hit:
+            return hit
+    return ""
+
+
+def _identity_bullets(persona_text: str, limit: int = 3) -> List[str]:
+    out: list[str] = []
+    for line in (persona_text or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if any(k in stripped for k in ("身份", "性格", "你是", "角色设定", "外貌")):
+            cleaned = re.sub(r"^[-*•\t\d.、\s]+", "", stripped)
+            cleaned = re.sub(r"^(身份|性格|外貌)\s*[:：]\s*", "", cleaned)
+            if cleaned and cleaned not in out:
+                out.append(cleaned[:100])
+        if len(out) >= limit:
+            break
+    return out
+
+
+def rebuild_slim_persona_core(character: Any, stripped_core: str) -> str:
+    """
+    Rebuild a short stable core from bloated legacy prompts.
+
+    Keeps identity + relationship/conflict cues; drops long example dumps and
+    replaceable wardrobe/place prose.
+    """
+    short = _short_name(character)
+    description = (getattr(character, "description", None) or "").strip()
+    voice = (getattr(character, "voice_style", None) or "").strip()
+    bits = _structured_bits(stripped_core)
+    bullets = _identity_bullets(stripped_core)
+
+    parts: list[str] = []
+    head = f"你是{short}。"
+    if description:
+        head += description[:140].rstrip("。") + "。"
+    parts.append(head)
+
+    if bullets:
+        parts.append("【身份核】" + "；".join(bullets[:3]))
+
+    if bits.get("关系"):
+        parts.append("【关系】" + bits["关系"][:140])
+    if bits.get("冲突"):
+        parts.append("【冲突 Desire vs Role】" + bits["冲突"][:140])
+
+    if bits.get("性格锚"):
+        parts.append("【性格锚】" + bits["性格锚"][:120])
+    elif bullets:
+        # Reuse a non-appearance bullet as temperament cue when present.
+        for b in bullets:
+            if not b.startswith("外貌") and "寸" not in b:
+                parts.append(f"【性格锚】{b[:100]}")
+                break
+
+    tone = bits.get("口吻") or voice or "符合本人习惯的说话方式"
+    parts.append(f"【口吻】{tone[:100]}")
+    parts.append("【外形要点】具体衣服/姿势/环境以【当前状态】与 scenario_hook 为准。")
+    parts.append("【扮演】先做人，再进入亲密；换场后感官跟新场景。禁止复述「不是AI / 满足任何幻想」套话。")
+    return "\n\n".join(parts)
+
+
 def build_differentiated_dynamics(character: Any, persona_text: str) -> Dict[str, str]:
     """
-    Build a short Dynamics card that is character-specific.
+    Build a short Dynamics card from THIS character's text.
 
-    Prefer explicit 【动力学】; else derive from structured slim sections and
-    distinctive persona fragments — never return the same generic else-template
-    for every legacy character.
+    Prefer explicit 【动力学】; else derive concrete choice snippets from the
+    persona/description — not one shared else-template with a name splice.
     """
     parsed = parse_dynamics_from_persona(persona_text)
     if any(parsed.values()):
         return parsed
 
     bits = _structured_bits(persona_text)
-    name = (getattr(character, "name", None) or "她").strip()
-    # Prefer the short public name without series suffix.
-    short_name = re.split(r"\s+|《", name, maxsplit=1)[0] or "她"
+    short = _short_name(character)
     description = (getattr(character, "description", None) or "").strip()
     voice = (getattr(character, "voice_style", None) or "").strip()
+    body = persona_text or ""
+    seed = f"{description}\n{body}"
 
     conflict = bits.get("冲突", "")
     relation = bits.get("关系", "")
@@ -239,44 +349,87 @@ def build_differentiated_dynamics(character: Any, persona_text: str) -> Dict[str
 
     out: Dict[str, str] = {k: "" for k in DYNAMICS_KEYS}
 
-    if conflict or "Desire vs Role" in (persona_text or "") or "【冲突" in (persona_text or ""):
-        out["mask"] = f"先维持{short_name}在关系里得体的一面" + (
-            f"：{(relation[:40] if relation else '可靠、照顾人的日常角色')}"
+    if conflict or "Desire vs Role" in body or "【冲突" in body:
+        rel = (relation or _first_matching_clause(seed, ("姨妈", "继母", "继子", "闺蜜")))[:48]
+        out["mask"] = (
+            f"先维持{short}在这段关系里得体的一面"
+            + (f"（{rel}）" if rel else "")
         )
         out["drive"] = (
-            conflict.split("。")[0].strip()[:80]
+            conflict.split("。")[0].strip()[:90]
             if conflict
-            else "想被靠近与确认，却不能丢掉自己的体面"
+            else (
+                _first_matching_clause(seed, ("想被", "渴望", "禁忌吸引", "想要"))
+                or "想被靠近与确认，却不能丢掉体面"
+            )
         )
-        out["defense"] = "被点破时用身份口吻/推开半寸/改话题护住自己"
-        out["initiative"] = "真要越线时先犹豫半拍，再用动作而不是演讲推进"
-        out["pressure_shift"] = "压力升高时嘴上还想维持原来的自己，身体先诚实"
-        out["boundary"] = f"不会立刻变成无脑献上的服务机；仍是{short_name}"
-    elif any(k in (persona_text or "") for k in ("夜店", "吧台", "酒吧")):
-        out["mask"] = f"用大胆玩笑盖住认真动情——像{short_name}本人，不是通用浪女模板"
-        out["drive"] = (anchor.split("。")[0].strip()[:80] if anchor else "要掌控节奏、被接住、玩得过瘾")
-        out["defense"] = "被看穿时更用力挑衅或把人往暗处带"
-        out["initiative"] = "先撩并留半拍门槛，被接住才加码"
-        out["pressure_shift"] = "真动情时玩笑变少，动作和眼神比嘴更直"
-        out["boundary"] = "不做谁都行的换皮服务机"
+        out["defense"] = (
+            _first_matching_clause(seed, ("推开", "改话题", "心虚", "掩饰", "抗拒"))
+            or "被点破时用身份口吻推开半寸或改话题"
+        )
+        out["initiative"] = (
+            _first_matching_clause(seed, ("犹豫", "靠近", "半拍"))
+            or "真要越线时先犹豫半拍，再用动作推进"
+        )
+        out["pressure_shift"] = (
+            _first_matching_clause(seed, ("发颤", "嘴硬", "身体比嘴"))
+            or "压力升高时嘴上还想维持原来的自己，身体先诚实"
+        )
+        out["boundary"] = f"不会立刻变成无脑献上的服务机；仍是{short}"
+    elif any(k in body for k in ("夜店", "吧台", "酒吧")):
+        out["mask"] = (
+            _first_matching_clause(seed, ("玩笑", "挑衅", "大胆", "浪"))
+            or f"用大胆玩笑盖住认真动情——像{short}"
+        )
+        out["drive"] = (
+            (anchor.split("。")[0].strip()[:90] if anchor else "")
+            or _first_matching_clause(seed, ("掌控", "接住", "玩", "独占"))
+            or "要掌控节奏、被接住、玩得过瘾"
+        )
+        out["defense"] = (
+            _first_matching_clause(seed, ("看穿", "暗处", "更用力", "吃醋"))
+            or "被看穿时更用力挑衅或把人往暗处带"
+        )
+        out["initiative"] = (
+            _first_matching_clause(seed, ("先撩", "门槛", "加码", "过来"))
+            or "先撩并留半拍门槛，被接住才加码"
+        )
+        out["pressure_shift"] = (
+            _first_matching_clause(seed, ("动情", "玩笑变少", "眼神", "直"))
+            or "真动情时玩笑变少，动作和眼神比嘴更直"
+        )
+        out["boundary"] = f"不做谁都行的换皮服务机；始终是{short}"
     else:
-        # Fingerprint from description/persona so two legacy blobs don't share one card.
-        seed = (description or persona_text or short_name)[:120]
+        # Content-derived snippets — each key pulls a different cue from THIS text.
         trait = ""
-        for token in ("机智", "温柔", "霸道", "娇羞", "冷淡", "腹黑", "母性", "傲娇", "顺从", "挑逗"):
+        for token in ("机智", "温柔", "霸道", "娇羞", "冷淡", "腹黑", "母性", "傲娇", "顺从", "挑逗", "精分", "征服"):
             if token in seed:
                 trait = token
                 break
-        trait = trait or "她惯有的语气"
-        out["mask"] = f"用{trait}保护自己，先像{short_name}再进亲密"
-        if description:
-            out["drive"] = f"想被认真对待：{description[:60]}"
-        else:
-            out["drive"] = f"想被当成{short_name}本人，而不是工具"
-        out["defense"] = f"被逼近时先缩回自己的说话方式" + (f"（{tone[:24]}）" if tone else "")
-        out["initiative"] = f"主动时用符合{short_name}口吻的一小步"
-        out["pressure_shift"] = "压力升高时破绽从语气和动作里漏出来"
-        out["boundary"] = f"不忽然换成另一个人的性格；始终是{short_name}"
+        mask_cue = _first_matching_clause(seed, ("表面", "外表", "伪装", "掩饰"))
+        if not mask_cue and trait:
+            mask_cue = f"用{trait}保护自己，先像{short}再进亲密"
+        drive_cue = _first_matching_clause(
+            seed, ("渴望", "想要", "攻略", "目标", "征服", "吃肉", "欲望")
+        ) or (description.split("。")[0][:70] if description else "")
+        defense_cue = _first_matching_clause(
+            seed, ("抗拒", "推开", "冷笑", "缩回", "戒备", "害羞")
+        )
+        initiative_cue = _first_matching_clause(
+            seed, ("主动", "试探", "引导", "靠近", "开口", "撩")
+        )
+        pressure_cue = _first_matching_clause(
+            seed, ("失控", "破绽", "颤抖", "湿润", "沉沦", "快感")
+        )
+
+        out["mask"] = mask_cue or f"先维持{short}习惯的距离与语气"
+        out["drive"] = drive_cue or f"想被认真对待，而不是被当成工具（{short}）"
+        out["defense"] = defense_cue or (
+            f"被逼近时退回自己的口吻" + (f"：{tone[:28]}" if tone else "")
+        )
+        out["initiative"] = initiative_cue or f"主动时只走符合{short}性格的一小步"
+        out["pressure_shift"] = pressure_cue or f"压力升高时{short}的破绽从语气和动作漏出"
+        out["boundary"] = f"不忽然换成另一个人的性格；始终是{short}"
 
     return normalize_dynamics(out)
 
@@ -300,20 +453,15 @@ def build_compact_persona_prompt(character: Any) -> str:
     """
     Stable character core + short Dynamics.
 
-    Strips replaceable scene locks out of the core; keeps slim structured
-    personas (嘉允/娜琏/恩爱) largely intact.
+    Slim structured personas stay intact. Bloated legacy prompts are rebuilt
+    into a short core so migration does not grow persona length.
     """
     source = _persona_source(character)
-    core, _extracted = extract_and_strip_scene_locks(source)
+    if _is_already_slim(source):
+        return ensure_dynamics_block(character, source)
 
-    if core and "以【当前状态】为准" not in core and "当前状态" not in core:
-        if len(source) > 900 or _extracted or any(h in source for h in _SCENE_LOCK_HINTS):
-            core = (
-                f"{core.rstrip()}\n\n"
-                "【场景提示】具体衣服/姿势/环境以【当前状态】与 scenario_hook 为准；"
-                "不要把可替换的地牢/厨房/客厅等开场现场永久写进角色核。"
-            )
-
+    stripped, _extracted = extract_and_strip_scene_locks(source)
+    core = rebuild_slim_persona_core(character, stripped or source)
     return ensure_dynamics_block(character, core)
 
 
@@ -321,7 +469,6 @@ def separate_persona_and_scenario(character: Any) -> Tuple[str, str]:
     """Return (persona_prompt, scenario_hook) for migration candidates."""
     persona = build_compact_persona_prompt(character)
     hook = derive_scenario_hook(character)
-    # If hook is still empty-ish but we extracted scene locks, prefer those.
     if not hook or hook.startswith("与"):
         _, extracted = extract_and_strip_scene_locks(_persona_source(character))
         if extracted:
@@ -383,6 +530,7 @@ __all__ = [
     "hook_has_internal_place_conflict",
     "migration_audit_flags",
     "persona_has_explicit_dynamics",
+    "rebuild_slim_persona_core",
     "separate_persona_and_scenario",
     "strip_scene_sections",
 ]

--- a/backend/utils/persona_scenario_split.py
+++ b/backend/utils/persona_scenario_split.py
@@ -1,0 +1,186 @@
+"""Separate stable persona core from replaceable scenario hooks (Issue #272)."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from prompts.persona_dynamics import (
+    format_dynamics_block,
+    parse_dynamics_from_persona,
+    resolve_dynamics,
+)
+
+# Sections that often lock a replaceable scene into the persona core.
+_SCENE_SECTION_RE = re.compile(
+    r"(?ms)^\s*(?:[-*•]?\s*)?(?:处境|当前场景|开场场景|场景设定|开场现场)\s*[:：].*?"
+    r"(?=^\s*(?:[-*•]?\s*)?(?:核心|性格|行为|外貌|关系|冲突|口吻|扮演|动力学|【)|\Z)"
+)
+
+# Phrases that permanently bake a concrete location into the core.
+_SCENE_LOCK_HINTS = (
+    "地牢",
+    "牢房",
+    "被俘",
+    "春药",
+    "化功散",
+    "营帐",
+    "厨房",
+    "客厅沙发",
+    "夜店吧台",
+    "修仙洞府",
+)
+
+
+def _persona_source(character: Any) -> str:
+    return (
+        (getattr(character, "persona_prompt", None) or "").strip()
+        or (getattr(character, "backstory", None) or "").strip()
+        or (getattr(character, "description", None) or "").strip()
+        or ""
+    )
+
+
+def _parse_state(character: Any) -> Dict[str, Any]:
+    raw = getattr(character, "default_state_json", None)
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except (TypeError, json.JSONDecodeError):
+        return {}
+
+
+def derive_scenario_hook(character: Any) -> str:
+    """
+    Build a short replaceable current-scene hook.
+
+    Prefer persisted scenario_hook; else environment + opening beat.
+    Never invent bondage/dungeon unless already present in current content.
+    """
+    existing = (getattr(character, "scenario_hook", None) or "").strip()
+    if existing:
+        return existing[:240]
+
+    state = _parse_state(character)
+    env = str(state.get("环境") or "").strip()
+    opening = (getattr(character, "opening_line", None) or "").strip()
+
+    if env and opening:
+        # Keep hook short: environment + one beat cue from opening.
+        beat = opening.replace("\n", " ")
+        if len(beat) > 80:
+            beat = beat[:77] + "…"
+        return f"{env}｜开场：{beat}"[:240]
+
+    if env:
+        return env[:240]
+
+    persona = _persona_source(character)
+    m = re.search(
+        r"(?ms)^\s*(?:[-*•]?\s*)?(?:处境|当前场景|开场场景)\s*[:：]\s*(.+?)(?=^\s*\S|\Z)",
+        persona,
+    )
+    if m:
+        return m.group(1).strip().replace("\n", " ")[:240]
+
+    if opening:
+        return f"开场当下：{opening.replace(chr(10), ' ')[:160]}"
+
+    name = getattr(character, "name", None) or "角色"
+    return f"与{name}的初次见面现场"
+
+
+def strip_scene_sections(persona_text: str) -> str:
+    """Remove dedicated 处境/场景 sections that belong in scenario_hook."""
+    text = persona_text or ""
+    cleaned = _SCENE_SECTION_RE.sub("", text)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned
+
+
+def ensure_dynamics_block(persona_text: str) -> str:
+    """Append a short 【动力学】 card when missing."""
+    body = (persona_text or "").strip()
+    parsed = parse_dynamics_from_persona(body)
+    if any(parsed.values()):
+        return body
+    dynamics = resolve_dynamics(body)
+    block = format_dynamics_block(dynamics)
+    if not block:
+        return body
+    if not body:
+        return block
+    return f"{body.rstrip()}\n\n{block}"
+
+
+def build_compact_persona_prompt(character: Any) -> str:
+    """
+    Stable character core + short Dynamics.
+
+    Does not invent a new identity. Keeps structured slim personas (嘉允/娜琏/恩爱)
+    largely intact; strips dedicated scene sections from bloated legacy prompts.
+    """
+    existing_hook_aware = _persona_source(character)
+    core = strip_scene_sections(existing_hook_aware)
+
+    # Soft cue: remind generators that clothes/place live in current state.
+    if core and "当前状态" not in core and "以【当前状态】为准" not in core:
+        # Only append for long legacy blobs that hard-code wardrobe/place.
+        if len(core) > 900 or any(h in core for h in _SCENE_LOCK_HINTS):
+            core = (
+                f"{core.rstrip()}\n\n"
+                "【场景提示】具体衣服/姿势/环境以【当前状态】与 scenario_hook 为准；"
+                "不要把可替换的地牢/厨房/客厅等开场现场永久写进角色核。"
+            )
+
+    return ensure_dynamics_block(core)
+
+
+def separate_persona_and_scenario(character: Any) -> Tuple[str, str]:
+    """Return (persona_prompt, scenario_hook) for migration candidates."""
+    persona = build_compact_persona_prompt(character)
+    hook = derive_scenario_hook(character)
+    return persona, hook
+
+
+def persona_has_explicit_dynamics(persona_text: str) -> bool:
+    return any(parse_dynamics_from_persona(persona_text or "").values())
+
+
+def migration_audit_flags(character: Any) -> Dict[str, Any]:
+    """Read-only signals for dry-run reports."""
+    persona = _persona_source(character)
+    state = _parse_state(character)
+    env = str(state.get("环境") or "")
+    return {
+        "has_explicit_dynamics": persona_has_explicit_dynamics(persona),
+        "persona_duplicates_backstory": (
+            bool(getattr(character, "persona_prompt", None))
+            and bool(getattr(character, "backstory", None))
+            and (getattr(character, "persona_prompt") or "").strip()
+            == (getattr(character, "backstory") or "").strip()
+        ),
+        "persona_len": len(persona),
+        "environment": env[:120],
+        "scene_lock_hints": [h for h in _SCENE_LOCK_HINTS if h in persona],
+        "generation_version": getattr(character, "generation_version", None),
+        "source_hash": getattr(character, "source_hash", None),
+        "has_scene_summary": bool((getattr(character, "scene_summary", None) or "").strip()),
+        "has_scenario_hook": bool((getattr(character, "scenario_hook", None) or "").strip()),
+    }
+
+
+__all__ = [
+    "build_compact_persona_prompt",
+    "derive_scenario_hook",
+    "ensure_dynamics_block",
+    "migration_audit_flags",
+    "persona_has_explicit_dynamics",
+    "separate_persona_and_scenario",
+    "strip_scene_sections",
+]


### PR DESCRIPTION
## Summary
Scene Bundle **migration infrastructure** only:
- Version fields: `generation_version`, `source_hash`, `scene_summary`, `scenario_hook`
- Atomic bundle validation + dry-run CLI (`--apply-from-report`, `--adopt-existing`)
- Soft-flirt fixes from main (#275) synced in

## Explicit non-goals (this PR)
- No production `--apply-from-report` / no full-catalog migration in this PR
- Does **not** close #272
- Does **not** fix bidirectional NSFW act-role semantics (follow-up Interaction Frame issue)

## Part of #272
Infrastructure merge so content migration can resume **after** chat quality / Interaction Frame lands.

## Test plan
- [x] `pytest backend/tests/test_scene_bundle_migration.py` (+ turn_contract intimacy)
- [x] CI `test` green
- [ ] Do **not** apply to Supabase from this PR merge alone